### PR TITLE
Add: Dockerfile for CI & push image to GHCR

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,63 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'Dockerfile'
+      - '.github/workflows/docker-build.yml'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/cpp-dev
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Verify image
+        run: |
+          docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest bash -c "
+            gcc-15 --version > /dev/null &&
+            g++-15 --version > /dev/null &&
+            clang-20 --version > /dev/null &&
+            clang++-20 --version > /dev/null &&
+            cmake --version > /dev/null &&
+            ninja --version > /dev/null &&
+            echo 'All tools verified successfully!'
+          "

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:25.04
+
+LABEL maintainer="jaehyung"
+LABEL description="C++20 development environment with GCC 15, Clang 20, CMake, and Ninja"
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    CC=gcc-15 \
+    CXX=g++-15 \
+    BUILD_TYPE=Release
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    gcc-15 g++-15 \
+    clang-20 clang++-20 clang-format-20 clang-tidy-20 \
+    cmake ninja-build \
+    gdb valgrind \
+    git curl wget \
+    ca-certificates \
+    pkg-config \
+    python3 python3-pip \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN ln -sf /usr/bin/clang-format-20 /usr/bin/clang-format \
+ && ln -sf /usr/bin/clang-tidy-20 /usr/bin/clang-tidy
+
+WORKDIR /workspace
+
+RUN git config --global --add safe.directory /workspace
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
- Add Dockerfile for OS-independent C++ builds
    - Ubuntu 25.04,
    - GCC 15,
    - Clang 20,
    - CMake, and Ninja
- Add GitHub Actions workflow to build and push the Docker image to GitHub Container Registry
- Prepares container image for future CL usage