### PR TITLE
Implement skip_list module with Set adapter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,11 @@ add_executable(test_set
 )
 target_link_libraries(test_set PRIVATE j Catch2::Catch2WithMain)
 
+add_executable(bench_set
+        ${CMAKE_CURRENT_SOURCE_DIR}/test/datastructures/benchmark/bench_set.cpp
+)
+target_link_libraries(bench_set PRIVATE j Catch2::Catch2WithMain)
+
 # add_executable(main
 #         ${CMAKE_CURRENT_SOURCE_DIR}/test/main.cpp
 # )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(j
         ${CMAKE_CURRENT_SOURCE_DIR}/modules/j.cppm
         ${CMAKE_CURRENT_SOURCE_DIR}/modules/unique_ptr.cppm
         ${CMAKE_CURRENT_SOURCE_DIR}/modules/memory.cppm
+        ${CMAKE_CURRENT_SOURCE_DIR}/modules/traits.cppm
         ${CMAKE_CURRENT_SOURCE_DIR}/modules/algorithms/algorithm.cppm
         ${CMAKE_CURRENT_SOURCE_DIR}/modules/algorithms/heap_algo.cppm
         ${CMAKE_CURRENT_SOURCE_DIR}/modules/datastructures/Array/array.cppm
@@ -37,6 +38,7 @@ target_sources(j
         ${CMAKE_CURRENT_SOURCE_DIR}/modules/datastructures/Deque/deque.cppm
         ${CMAKE_CURRENT_SOURCE_DIR}/modules/datastructures/Deque/stack.cppm
         ${CMAKE_CURRENT_SOURCE_DIR}/modules/datastructures/Deque/queue.cppm
+        ${CMAKE_CURRENT_SOURCE_DIR}/modules/datastructures/Tree/tree_selector.cppm
 )
 
 # --------------- Add Tests and Benchmarks ---------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(j
         ${CMAKE_CURRENT_SOURCE_DIR}/modules/j.cppm
         ${CMAKE_CURRENT_SOURCE_DIR}/modules/unique_ptr.cppm
         ${CMAKE_CURRENT_SOURCE_DIR}/modules/memory.cppm
+        ${CMAKE_CURRENT_SOURCE_DIR}/modules/concepts.cppm
         ${CMAKE_CURRENT_SOURCE_DIR}/modules/traits.cppm
         ${CMAKE_CURRENT_SOURCE_DIR}/modules/algorithms/algorithm.cppm
         ${CMAKE_CURRENT_SOURCE_DIR}/modules/algorithms/heap_algo.cppm
@@ -39,6 +40,9 @@ target_sources(j
         ${CMAKE_CURRENT_SOURCE_DIR}/modules/datastructures/Deque/stack.cppm
         ${CMAKE_CURRENT_SOURCE_DIR}/modules/datastructures/Deque/queue.cppm
         ${CMAKE_CURRENT_SOURCE_DIR}/modules/datastructures/Tree/tree_selector.cppm
+        ${CMAKE_CURRENT_SOURCE_DIR}/modules/datastructures/Tree/Map/map.cppm
+        ${CMAKE_CURRENT_SOURCE_DIR}/modules/datastructures/Tree/Set/set.cppm
+        ${CMAKE_CURRENT_SOURCE_DIR}/modules/datastructures/Tree/Base/skip_list.cppm
 )
 
 # --------------- Add Tests and Benchmarks ---------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,11 @@ add_executable(bench_queue
 )
 target_link_libraries(bench_queue PRIVATE j Catch2::Catch2WithMain)
 
+add_executable(test_set
+        ${CMAKE_CURRENT_SOURCE_DIR}/test/datastructures/test_set.cpp
+)
+target_link_libraries(test_set PRIVATE j Catch2::Catch2WithMain)
+
 # add_executable(main
 #         ${CMAKE_CURRENT_SOURCE_DIR}/test/main.cpp
 # )
@@ -129,3 +134,6 @@ add_test(NAME test_list COMMAND test_list)
 add_test(NAME test_forward_list COMMAND test_forward_list)
 add_test(NAME test_vector COMMAND test_vector)
 add_test(NAME test_deque COMMAND test_deque)
+add_test(NAME test_stack COMMAND test_stack)
+add_test(NAME test_queue COMMAND test_queue)
+add_test(NAME test_set COMMAND test_set)

--- a/modules/concepts.cppm
+++ b/modules/concepts.cppm
@@ -1,0 +1,40 @@
+/*
+ * @ Created by jaehyung409 on 25. 9. 24..
+ * @ Copyright (c) 2025 jaehyung409
+ * This software is licensed under the MIT License.
+ */
+
+module;
+#include <concepts>
+
+#if defined(__clang__)
+export module j:concepts;
+#else
+module j:concepts;
+#endif
+
+namespace j {
+template <class K, class KeyType, class Comparator>
+concept IsTransparentlyComparable = requires(const K &k, const KeyType &key, const Comparator &comp) {
+    { comp(k, key) } -> std::convertible_to<bool>;
+    { comp(key, k) } -> std::convertible_to<bool>;
+};
+
+template <class Traits, class SourceTree>
+concept IsMergeable = std::is_same_v<typename Traits::key_type, typename SourceTree::key_type> &&
+                      std::is_same_v<typename Traits::value_type, typename SourceTree::value_type> &&
+                      std::is_same_v<typename Traits::key_compare, typename SourceTree::key_compare> &&
+                      std::is_same_v<typename Traits::allocator_type, typename SourceTree::allocator_type>;
+
+namespace detail {
+template <class TR, class K, class M>
+concept InsertOrAssignConstraint = !TR::_IS_SET && std::constructible_from<typename TR::value_type, K &&, M &&> &&
+                                   std::assignable_from<typename TR::mapped_type &, M> &&
+                                   IsTransparentlyComparable<K, typename TR::key_type, typename TR::key_compare>;
+
+template <class TR, class K, class... Args>
+concept TryEmplaceConstraint =
+    !TR::_IS_SET && !TR::_MULTI && std::constructible_from<typename TR::mapped_type, Args...> &&
+    IsTransparentlyComparable<K, typename TR::key_type, typename TR::key_compare>;
+} // namespace detail
+} // namespace j

--- a/modules/datastructures/Tree/Base/skip_list.cppm
+++ b/modules/datastructures/Tree/Base/skip_list.cppm
@@ -1,142 +1,1314 @@
 /*
  * @ Created by jaehyung409 on 25. 9. 16..
- * @ Copyright (c) 2025 jaehyung409 
- * This software is licensed under the MIT License. 
+ * @ Copyright (c) 2025 jaehyung409
+ * This software is licensed under the MIT License.
  */
 
 module;
-#include <utility>
-#include <memory>
 #include <functional>
+#include <memory>
 #include <random>
+#include <unordered_map>
+#include <utility>
 
+#if defined(__clang__)
 export module j:skip_list;
+#else
+module j:skip_list;
+#endif
 
-import :traits;
+import :concepts;
+import :memory;
+import :unique_ptr;
 import :vector;
+import :array;
 
 namespace j {
-export template <class Value, class Compare, class Allocator>
-class skip_list : private value_compare_traits<
-                     typename key_traits<Value>::key_type,
-                     Value,
-                     Compare,
-                     key_traits<Value>>::value_compare {
-public:
-    using value_type = Value;
-    using key_type   = typename key_traits<Value>::key_type;
-    using mapped_type = typename key_traits<Value>::mapped_type; // for map, multimap
-    using key_compare = Compare;
-    using value_compare = typename value_compare_traits<key_type, value_type, Compare, key_traits<Value>>::value_compare; // EBO
-    using allocator_type         = Allocator;
-    using pointer                = typename std::allocator_traits<Allocator>::pointer;
-    using const_pointer          = typename std::allocator_traits<Allocator>::const_pointer;
-    using reference              = value_type&;
-    using const_reference        = const value_type&;
-    using size_type = typename std::allocator_traits<Allocator>::size_type;
-    using difference_type = typename std::allocator_traits<Allocator>::difference_type;
-    using iterator = /* not yet */
-    using const_iterator = /* not yet */
-    using reverse_iterator       = std::reverse_iterator<iterator>;
-    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
-    struct node_type;
-    using insert_return_type     = std::pair<iterator, node_type>; // for set, map
+template <class Traits> class skip_list {
+  private:
+    class _iterator;
+    class _const_iterator;
+    static constexpr bool _MULTI = Traits::_MULTI;
+    static constexpr bool _IS_SET = std::is_same_v<typename Traits::key_type, typename Traits::value_type>;
 
-    skip_list() : skip_list(Compare()) {}
-    explicit skip_list(const Compare& comp, const Allocator& alloc = Allocator());
-    template<class InputIter>
-    requires std::input_iterator<InputIter>
-    skip_list(InputIter first, InputIter last, const Compare& comp = Compare(), const Allocator& alloc = Allocator());
-    skip_list(const skip_list& other);
-    skip_list(const skip_list& other, const Allocator& alloc);
-    skip_list(skip_list&& other);
-    skip_list(skip_list&& other, const Allocator& alloc);
-    skip_list(std::initializer_list<value_type> il, const Compare& comp = Compare(), const Allocator& alloc = Allocator());
-    skip_list& operator=(const skip_list& x);
-    skip_list& operator=(skip_list&& x);
-    skip_list& operator=(std::initializer_list<value_type> il);
-    ~skip_list();
-    allocator_type get_allocator() const noexcept;
+  public:
+    using value_type = typename Traits::value_type;
+    using key_type = typename Traits::key_type;
+    using mapped_type = typename Traits::mapped_type;
+    using key_compare = typename Traits::key_compare;
+    using value_compare = typename Traits::value_compare; //
+    using allocator_type = typename Traits::allocator_type;
+    using pointer = typename std::allocator_traits<allocator_type>::pointer;
+    using const_pointer = typename std::allocator_traits<allocator_type>::const_pointer;
+    using reference = value_type &;
+    using const_reference = const value_type &;
+    using size_type = typename std::allocator_traits<allocator_type>::size_type;
+    using difference_type = typename std::allocator_traits<allocator_type>::difference_type;
+    using iterator = std::conditional_t<_IS_SET, _const_iterator, _iterator>;
+    using const_iterator = _const_iterator;
+    // using reverse_iterator       = std::reverse_iterator<iterator>;
+    // using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+    struct node_type;
+    struct insert_return_type { // temp
+        iterator position;
+        bool inserted;
+        node_type node;
+    };
+
+    skip_list(const key_compare &comp, const allocator_type &alloc);
+    skip_list(const skip_list &other);
+    skip_list(const skip_list &other, const std::type_identity_t<allocator_type> &alloc);
+    skip_list(skip_list &&x);
+    skip_list(skip_list &&x, const std::type_identity_t<allocator_type> &alloc);
+    skip_list &operator=(const skip_list &x);
+    skip_list &operator=(skip_list &&x) noexcept(std::allocator_traits<allocator_type>::is_always_equal::value &&
+                                                 std::is_nothrow_move_assignable_v<key_compare>);
+    ~skip_list() noexcept;
 
     iterator begin() noexcept;
-    const_iterator begin() const noexcept;
-    iterator end() noexcept;
-    const_iterator end() const noexcept;
-    reverse_iterator rbegin() noexcept;
-    const_reverse_iterator rbegin() const noexcept;
-    reverse_iterator rend() noexcept;
-    const_reverse_iterator rend() const noexcept;
-
     const_iterator cbegin() const noexcept;
+    iterator end() noexcept;
     const_iterator cend() const noexcept;
-    const_reverse_iterator crbegin() const noexcept;
-    const_reverse_iterator crend() const noexcept;
 
     [[nodiscard]] bool empty() const noexcept;
     [[nodiscard]] size_type size() const noexcept;
     [[nodiscard]] size_type max_size() const noexcept;
+    [[nodiscard]] allocator_type get_allocator() const noexcept;
 
+    template <class... Args>
+        requires std::constructible_from<value_type, Args &&...>
+    std::pair<iterator, bool> emplace(Args &&...args);
+    template <class... Args>
+        requires std::constructible_from<value_type, Args &&...>
+    iterator emplace_hint(const_iterator position, Args &&...args);
+    template <class InputIter>
+        requires std::input_iterator<InputIter>
+    void insert(InputIter first, InputIter last);
+    node_type extract(const_iterator position);
 
-    auto lower_bound(const key_type& key) const;
-    template<class... Args>
-    auto emplace(const_iterator position, Args&&... args);
-    auto erase(const_iterator position);
-    auto insert(const iterator position, node_type node);
-    auto extract(const_iterator position);
-    void clear();
-    void swap(skip_list& other) noexcept;
+    // Defined inline because the iterator would prevent matching with a separate declaration/definition.
+    template <class K>
+        requires(IsTransparentlyComparable<K, key_type, key_compare> &&
+                 !std::is_convertible_v<std::remove_cvref_t<K>, iterator> &&
+                 !std::is_convertible_v<std::remove_cvref_t<K>, const_iterator>)
+    node_type extract(K &&x) {
+        if (auto it = find(std::forward<K>(x)); it != end()) {
+            return extract(it);
+        }
+        return node_type();
+    }
 
-private:
+    insert_return_type insert(node_type &&nh);
+    iterator insert(const_iterator hint, node_type &&nh);
+
+    template <class K, class... Args>
+        requires detail::TryEmplaceConstraint<skip_list, K, Args...>
+    iterator try_emplace(K &&key, Args &&...args);
+    template <class K, class... Args>
+        requires detail::TryEmplaceConstraint<skip_list, K, Args...>
+    iterator try_emplace(const_iterator position, K &&key, Args &&...args);
+    template <class K, class M>
+        requires detail::InsertOrAssignConstraint<skip_list, K, M>
+    iterator insert_or_assign(K &&key, M &&obj);
+    template <class K, class M>
+        requires detail::InsertOrAssignConstraint<skip_list, K, M>
+    iterator insert_or_assign(const_iterator position, K &&key, M &&obj);
+
+    iterator erase(const_iterator position);
+
+    // Defined inline because the iterator would prevent matching with a separate declaration/definition.
+    template <class K>
+        requires(IsTransparentlyComparable<K, key_type, key_compare> &&
+                 !std::is_convertible_v<std::remove_cvref_t<K>, iterator> &&
+                 !std::is_convertible_v<std::remove_cvref_t<K>, const_iterator>)
+    size_type erase(K &&key) {
+        size_type count = 0;
+        auto range = equal_range(std::forward<K>(key));
+        while (range.first != range.second) {
+            range.first = erase(range.first);
+            ++count;
+        }
+        return count;
+    }
+
+    iterator erase(const_iterator first, const_iterator last);
+    void swap(skip_list &x) noexcept(std::allocator_traits<allocator_type>::is_always_equal::value &&
+                                     std::is_nothrow_swappable_v<key_compare>);
+
+    void clear() noexcept;
+
+    template <class SourceTree>
+        requires IsMergeable<Traits, SourceTree>
+    void merge(SourceTree &source) = delete; // will implement slow path, and heterogeneous merge later
+    void merge(skip_list &source);           // fast path only (same key_compare, same tree type)
+
+    [[nodiscard]] key_compare key_comp() const;
+    [[nodiscard]] value_compare value_comp() const;
+
+    template <class K>
+        requires IsTransparentlyComparable<K, key_type, key_compare>
+    iterator find(K &&key);
+    template <class K>
+        requires IsTransparentlyComparable<K, key_type, key_compare>
+    const_iterator find(K &&key) const;
+
+    template <class K>
+        requires IsTransparentlyComparable<K, key_type, key_compare>
+    size_type count(K &&key) const;
+
+    template <class K>
+        requires IsTransparentlyComparable<K, key_type, key_compare>
+    bool contains(K &&key) const;
+
+    template <class K>
+        requires IsTransparentlyComparable<K, key_type, key_compare>
+    iterator lower_bound(K &&key);
+    template <class K>
+        requires IsTransparentlyComparable<K, key_type, key_compare>
+    const_iterator lower_bound(K &&key) const;
+
+    template <class K>
+        requires IsTransparentlyComparable<K, key_type, key_compare>
+    iterator upper_bound(K &&key);
+    template <class K>
+        requires IsTransparentlyComparable<K, key_type, key_compare>
+    const_iterator upper_bound(K &&key) const;
+
+    template <class K>
+        requires IsTransparentlyComparable<K, key_type, key_compare>
+    std::pair<iterator, iterator> equal_range(K &&key);
+    template <class K>
+        requires IsTransparentlyComparable<K, key_type, key_compare>
+    std::pair<const_iterator, const_iterator> equal_range(K &&key) const;
+
+  private:
     struct _skip_list_node;
     using Node = _skip_list_node;
-    using node_allocator_type = typename std::allocator_traits<Allocator>::template rebind_alloc<Node>;
+    using node_ptr = Node *;
+    using node_allocator_type = typename std::allocator_traits<allocator_type>::template rebind_alloc<Node>;
     mutable std::mt19937 rng;
-    mutable std::bernoulli_distribution coin_flip{0.5};
+    mutable std::bernoulli_distribution coin_flip{0.5}; // later, make it customizable
+
+    class node_forward_guard;
+    struct _strategy_copy {
+        static constexpr bool copy = true;
+    };
+    struct _strategy_move {
+        static constexpr bool copy = false;
+    };
+    class copy_guard;
 
     static const size_type MAX_LEVEL = 32;
-    Node* _header; // header node
-    Node* _tail;   // tail node
+    size_type _max_level; // update only when inserting a new node with higher level (not decrease)
+    node_ptr _dummy;
     node_allocator_type _node_alloc;
     size_type _size;
+    [[no_unique_address]] key_compare _key_comp;
 
-    size_type _random_level() const {
-        size_type level = 0;
-        while (coin_flip(rng)) {
-            ++level;
-        }
-        return level;
-    }
-    void _find_predecessors(const key_type& key, vector<Node*>& predecessors) const; // 아직 구조를 확정 못함.
+    size_type _random_level() const;
+    // Calling `construct` with a level-only constructor would complicate safe initialization and could cause UB.
+    // Therefore, we treat Node as POD-like and manually initialize `_level` (and '_forward').
+    [[nodiscard]] auto _construct_node(size_type level) -> node_forward_guard;
+    void _deallocate_dummy_node() noexcept;
+    void _deallocate_node(node_ptr node) noexcept;
+    template <class K>
+        requires IsTransparentlyComparable<K, key_type, key_compare>
+    auto _find_predecessors(K &&key) const -> array<node_ptr, MAX_LEVEL + 1>;
+    void _update_predecessors(const key_type key, array<node_ptr, MAX_LEVEL + 1> &predecessors);
+    template <class K>
+        requires IsTransparentlyComparable<K, key_type, key_compare>
+    bool _is_duplicate(K &&key, node_ptr next) const;
+    template <class V>
+        requires std::constructible_from<value_type, V>
+    auto _init_node(V &&value, size_type level) -> node_forward_guard;
+    void _init_dummy();
+    void _move_state(skip_list &&x);
+    template <class Strategy> void _clone_tree(const skip_list &x);
+    void _destroy_tree() noexcept;
+
+    template <class K>
+        requires IsTransparentlyComparable<K, key_type, key_compare>
+    const_iterator _find_lower_bound(K &&key) const;
+    template <class K>
+        requires IsTransparentlyComparable<K, key_type, key_compare>
+    const_iterator _find_upper_bound(K &&key) const;
+
+    node_ptr _extract_node(const_iterator position);
+    void _insert_node(node_ptr new_node, array<node_ptr, MAX_LEVEL + 1> &predecessors) noexcept;
+
+    template <class... Args>
+        requires std::constructible_from<value_type, Args &&...>
+    std::pair<iterator, bool> _emplace(size_type level, Args &&...args);
+
+    template <class K, class... Args>
+        requires detail::TryEmplaceConstraint<skip_list<Traits>, K, Args...>
+    iterator _try_emplace(K &&key, size_type level, Args &&...args);
+
+    template <class K, class M>
+        requires detail::InsertOrAssignConstraint<skip_list<Traits>, K, M>
+    iterator _insert_or_assign(K &&key, M &&obj, size_type level);
 };
 
-// non-member functions will be added later
-
-template <class Value, class Compare, class Allocator>
-struct skip_list<Value, Compare, Allocator>::_skip_list_node {
+template <class Traits> struct skip_list<Traits>::_skip_list_node {
     friend skip_list;
-    friend iterator;
-    friend const_iterator;
-private:
+    friend _iterator;
+    friend _const_iterator;
+
+  private:
+    using node_pointer = _skip_list_node *;
     value_type _value;
     size_type _level;
-    vector<Node*> _forward; // forward[i] = next node at level i
-    Node* _backward;
+    node_pointer *_forward; // forward[i] = next node at level i
+    node_pointer _backward;
 
-    explicit _skip_list_node(value_type& value) : _value(value) {
-        _level = _random_level();
-        _forward = vector<Node*>(_level + 1, nullptr);
-        _backward = nullptr;
+    const key_type &_key() const noexcept {
+        if constexpr (_IS_SET) {
+            return _value; // set
+        } else {
+            return _value.first; // map
+        }
     }
-    ~_skip_list_node() = default; // destructor will be defined later
-};
-template <class Value, class Compare, class Allocator>
-template <bool IsConst>
-class skip_list<Value, Compare, Allocator>::_iterator_impl {};
 
-template <class Value, class Compare, class Allocator>
-struct skip_list<Value, Compare, Allocator>::node_type {};
-}
+  public:
+    ~_skip_list_node() = default;
+};
+
+template <class Traits> class skip_list<Traits>::_iterator {
+    friend skip_list;
+    friend _const_iterator;
+
+  public:
+    using iterator_concept = std::bidirectional_iterator_tag;
+    using iterator_category = std::bidirectional_iterator_tag;
+    using value_type = typename skip_list::value_type;
+    using difference_type = typename skip_list::difference_type;
+    using pointer = typename skip_list::pointer;
+    using reference = typename skip_list::reference;
+
+  private:
+    using node_pointer = Node *;
+    node_pointer _ptr;
+
+  public:
+    explicit _iterator(node_pointer ptr = nullptr) noexcept : _ptr(ptr) {}
+    _iterator &operator=(const const_iterator &other) noexcept {
+        _ptr = other._ptr;
+        return *this;
+    }
+
+    reference operator*() const noexcept {
+        return _ptr->_value;
+    }
+    pointer operator->() const noexcept {
+        return &(_ptr->_value);
+    }
+
+    _iterator &operator++() noexcept {
+        _ptr = _ptr->_forward[0];
+        return *this;
+    }
+
+    _iterator operator++(int) noexcept {
+        _iterator temp = *this;
+        ++(*this);
+        return temp;
+    }
+
+    _iterator &operator--() noexcept {
+        _ptr = _ptr->_backward;
+        return *this;
+    }
+
+    _iterator operator--(int) noexcept {
+        _iterator temp = *this;
+        --(*this);
+        return temp;
+    }
+
+    bool operator==(const _iterator &other) const noexcept {
+        return _ptr == other._ptr;
+    }
+
+    friend bool operator==(const _iterator &lhs, const _const_iterator &rhs) noexcept {
+        return lhs._ptr == rhs._ptr;
+    }
+};
+
+template <class Traits> class skip_list<Traits>::_const_iterator {
+    friend skip_list;
+    friend _iterator;
+
+  public:
+    using iterator_concept = std::bidirectional_iterator_tag;
+    using iterator_category = std::bidirectional_iterator_tag;
+    using value_type = typename skip_list::value_type;
+    using difference_type = typename skip_list::difference_type;
+    using pointer = typename skip_list::pointer;
+    using reference = typename skip_list::reference;
+
+  private:
+    using node_pointer = Node *;
+    node_pointer _ptr;
+
+  public:
+    explicit _const_iterator(node_pointer ptr = nullptr) noexcept : _ptr(ptr) {}
+    _const_iterator(const _iterator &other) noexcept : _ptr(other._ptr) {}
+    _const_iterator &operator=(const _const_iterator &other) noexcept {
+        _ptr = other._ptr;
+        return *this;
+    }
+
+    const_reference operator*() const noexcept {
+        return _ptr->_value;
+    }
+    const_pointer operator->() const noexcept {
+        return &(_ptr->_value);
+    }
+
+    _const_iterator &operator++() noexcept {
+        _ptr = _ptr->_forward[0];
+        return *this;
+    }
+
+    _const_iterator operator++(int) noexcept {
+        _const_iterator temp = *this;
+        ++(*this);
+        return temp;
+    }
+
+    _const_iterator &operator--() noexcept {
+        _ptr = _ptr->_backward;
+        return *this;
+    }
+
+    _const_iterator operator--(int) noexcept {
+        _const_iterator temp = *this;
+        --(*this);
+        return temp;
+    }
+
+    bool operator==(const _const_iterator &other) const noexcept {
+        return _ptr == other._ptr;
+    }
+
+    template <class T>
+    friend bool operator==(const skip_list<T>::_iterator &lhs, const skip_list<T>::_const_iterator &rhs) noexcept;
+};
+
+template <class Traits>
+struct skip_list<Traits>::node_type { // node hanlder 구현이
+                                      // 잘못됨.https://en.cppreference.com/w/cpp/container/node_handle.html
+    friend skip_list;
+
+  public:
+    using allocator_type = typename skip_list::allocator_type;
+    using key_type = typename skip_list::key_type;
+    using mapped_type = typename skip_list::mapped_type;
+    using value_type = typename skip_list::value_type;
+
+  private:
+    using Node = _skip_list_node;
+    using node_ptr = Node *;
+    node_ptr _ptr;
+    allocator_type _alloc;
+    size_type _level; // level of the node, used for deallocation
+    static constexpr bool _IS_SET = std::is_same_v<key_type, value_type>;
+    void _reset() {
+        if (_ptr) {
+            using node_allocator_type = typename std::allocator_traits<allocator_type>::template rebind_alloc<Node>;
+            node_allocator_type _node_alloc(_alloc);
+            if (_ptr->_forward) {
+                using node_ptr_allocator =
+                    typename std::allocator_traits<node_allocator_type>::template rebind_alloc<node_ptr>;
+                node_ptr_allocator _node_ptr_alloc(_node_alloc);
+                std::allocator_traits<node_ptr_allocator>::deallocate(_node_ptr_alloc, _ptr->_forward, _level + 1);
+                _ptr->_forward = nullptr;
+            }
+            std::allocator_traits<node_allocator_type>::destroy(_node_alloc, &_ptr->_value);
+            std::allocator_traits<node_allocator_type>::deallocate(_node_alloc, _ptr, 1);
+            _ptr = nullptr;
+        }
+        _level = 0;
+    }
+
+  public:
+    explicit node_type() : _ptr(nullptr), _alloc(allocator_type()), _level(0) {}
+    explicit node_type(node_ptr ptr, const allocator_type &alloc) : _ptr(ptr), _alloc(alloc) {
+        _level = ptr ? ptr->_level : 0;
+    }
+    node_type(const node_type &) = delete;
+    node_type &operator=(const node_type &) = delete;
+    node_type(node_type &&other) noexcept
+        : _ptr(std::exchange(other._ptr, nullptr)), _alloc(other._alloc), _level(other._level) {}
+    node_type &operator=(node_type &&other) noexcept {
+        if (this != &other) {
+            _reset();
+            _ptr = std::exchange(other._ptr, nullptr);
+            _alloc = std::move(other._alloc);
+            _level = std::exchange(other._level, 0);
+            other._level = 0;
+        }
+        return *this;
+    }
+    ~node_type() {
+        _reset();
+    } // destructor only node_type is out of tree
+
+    bool empty() const noexcept {
+        return _ptr == nullptr;
+    }
+
+    allocator_type get_allocator() const noexcept {
+        return _alloc;
+    }
+
+    void swap(node_type &other) noexcept {
+        using std::swap;
+        swap(_ptr, other._ptr);
+        swap(_alloc, other._alloc);
+        swap(_level, other._level);
+    }
+
+    const key_type &key() const
+        requires(!_IS_SET)
+    {
+        return _ptr->_value.first;
+    }
+
+    auto &mapped() const
+        requires(!_IS_SET)
+    { // to avoid compile error in set/multi_set
+        return _ptr->_value.second;
+    }
+
+    value_type &value() const
+        requires(_IS_SET)
+    {
+        return _ptr->_value;
+    }
+};
+
+template <class Traits> class skip_list<Traits>::node_forward_guard {
+  private:
+    node_ptr _ptr;
+    node_allocator_type _node_alloc;
+    size_type _level;
+
+  public:
+    node_forward_guard() : _ptr(nullptr), _level(0) {}
+    node_forward_guard(node_ptr node_ptr, const node_allocator_type &node_alloc, size_type level)
+        : _ptr(node_ptr), _node_alloc(node_alloc), _level(level) {
+        _ptr->_forward = nullptr;
+        _ptr->_level = level;
+    }
+    ~node_forward_guard() {
+        if (_ptr) {
+            if (_ptr->_forward) {
+                using node_ptr_allocator =
+                    typename std::allocator_traits<node_allocator_type>::template rebind_alloc<node_ptr>;
+                node_ptr_allocator _node_ptr_alloc(_node_alloc);
+                std::allocator_traits<node_ptr_allocator>::deallocate(_node_ptr_alloc, _ptr->_forward, _level + 1);
+                _ptr->_forward = nullptr;
+            }
+            std::allocator_traits<node_allocator_type>::destroy(_node_alloc, _ptr);
+            std::allocator_traits<node_allocator_type>::deallocate(_node_alloc, _ptr, 1);
+            _ptr = nullptr;
+        }
+    }
+    node_forward_guard(const node_forward_guard &) = delete;
+    node_forward_guard &operator=(const node_forward_guard &) = delete;
+    node_forward_guard(node_forward_guard &&other) noexcept : _ptr(other._ptr), _node_alloc(other._node_alloc) {
+        other._ptr = nullptr;
+    }
+    // move assignment should not be used
+    node_forward_guard &operator=(node_forward_guard &&) = delete;
+
+    node_ptr release() noexcept {
+        node_ptr temp = _ptr;
+        _ptr = nullptr;
+        return temp;
+    }
+
+    node_ptr get() const noexcept {
+        return _ptr;
+    }
+};
+
+template <class Traits> class skip_list<Traits>::copy_guard {
+  private:
+    std::unordered_map<node_ptr, node_ptr> _node_map; // later, use custom hash function
+    node_allocator_type _node_alloc;
+
+  public:
+    explicit copy_guard(const node_allocator_type &node_alloc) : _node_alloc(node_alloc) {};
+    copy_guard(const copy_guard &) = delete;
+    copy_guard &operator=(const copy_guard &) = delete;
+    copy_guard(copy_guard &&) = delete;
+    copy_guard &operator=(copy_guard &&) = delete;
+    ~copy_guard() {
+        for (auto &[old_node, new_node] : _node_map) {
+            if (new_node) {
+                std::allocator_traits<node_allocator_type>::destroy(_node_alloc, &new_node->_value);
+                std::allocator_traits<node_allocator_type>::destroy(_node_alloc, new_node);
+                std::allocator_traits<node_allocator_type>::deallocate(_node_alloc, new_node, 1);
+                new_node = nullptr;
+            }
+        }
+    }
+
+    void insert(node_ptr old_node, node_ptr new_node) {
+        _node_map[old_node] = new_node;
+    }
+
+    node_ptr get_new_node(node_ptr old_node) const {
+        auto it = _node_map.find(old_node);
+        return (it != _node_map.end()) ? it->second : nullptr;
+    }
+
+    void release() {
+        _node_map.clear();
+    }
+};
+
+} // namespace j
 
 namespace j {
-
+template <class Traits> skip_list<Traits>::size_type skip_list<Traits>::_random_level() const {
+    size_type level = 0;
+    while (coin_flip(rng) && level <= MAX_LEVEL) {
+        ++level;
+    }
+    return level;
 }
+
+template <class Traits> auto skip_list<Traits>::_construct_node(size_type level) -> node_forward_guard {
+    node_forward_guard node_guard(std::allocator_traits<node_allocator_type>::allocate(_node_alloc, 1), _node_alloc,
+                                  level);
+
+    using node_ptr_allocator = typename std::allocator_traits<node_allocator_type>::template rebind_alloc<node_ptr>;
+    node_ptr_allocator _node_ptr_alloc(_node_alloc);
+    node_guard.get()->_forward = std::allocator_traits<node_ptr_allocator>::allocate(_node_ptr_alloc, level + 1);
+
+    return node_guard;
+}
+
+template <class Traits> void skip_list<Traits>::_deallocate_dummy_node() noexcept {
+    using node_ptr_allocator = typename std::allocator_traits<node_allocator_type>::template rebind_alloc<node_ptr>;
+    node_ptr_allocator _node_ptr_alloc(_node_alloc);
+    std::allocator_traits<node_ptr_allocator>::deallocate(_node_ptr_alloc, _dummy->_forward, _dummy->_level + 1);
+    std::allocator_traits<node_allocator_type>::deallocate(_node_alloc, _dummy, 1);
+}
+
+template <class Traits> void skip_list<Traits>::_deallocate_node(Node *node) noexcept {
+    std::allocator_traits<node_allocator_type>::destroy(_node_alloc, &node->_value);
+    using node_ptr_allocator = typename std::allocator_traits<node_allocator_type>::template rebind_alloc<node_ptr>;
+    node_ptr_allocator _node_ptr_alloc(_node_alloc);
+    std::allocator_traits<node_ptr_allocator>::deallocate(_node_ptr_alloc, node->_forward, node->_level + 1);
+    std::allocator_traits<node_allocator_type>::deallocate(_node_alloc, node, 1);
+}
+
+template <class Traits>
+template <class K>
+    requires IsTransparentlyComparable<K, typename Traits::key_type, typename Traits::key_compare>
+auto skip_list<Traits>::_find_predecessors(K &&key) const -> array<node_ptr, MAX_LEVEL + 1> {
+    array<node_ptr, MAX_LEVEL + 1> predecessors;
+    Node *current = _dummy;
+    for (size_type i = _max_level + 1; i > 0; --i) { // avoid unsigned int underflow
+        while (current->_forward[i - 1] != _dummy && _key_comp(current->_forward[i - 1]->_key(), key)) {
+            current = current->_forward[i - 1];
+        }
+        predecessors[i - 1] = current;
+    }
+    return predecessors;
+}
+
+// If we already know the predecessors and want to insert a new node after them,
+template <class Traits>
+void skip_list<Traits>::_update_predecessors(const key_type key, array<Node *, MAX_LEVEL + 1> &predecessors) {
+    for (size_type i = _max_level + 1; i > 0; --i) {
+        while (predecessors[i - 1]->_forward[i - 1] != _dummy &&
+               !_key_comp(key, predecessors[i - 1]->_forward[i - 1]->_key())) {
+            predecessors[i - 1] = predecessors[i - 1]->_forward[i - 1];
+        }
+    }
+}
+
+template <class Traits>
+template <class K>
+    requires IsTransparentlyComparable<K, typename Traits::key_type, typename Traits::key_compare>
+bool skip_list<Traits>::_is_duplicate(K &&key, Node *next) const {
+    return next != _dummy && !_key_comp(key, next->_key()) && !_key_comp(next->_key(), key);
+}
+
+template <class Traits>
+template <class V>
+    requires std::constructible_from<typename Traits::value_type, V>
+auto skip_list<Traits>::_init_node(V &&value, size_type level) -> node_forward_guard {
+    node_forward_guard node_guard(std::move(_construct_node(level)));
+    allocator_type _alloc = get_allocator();
+    std::allocator_traits<allocator_type>::construct(_alloc, &node_guard.get()->_value, std::forward<V>(value));
+
+    return node_guard;
+}
+
+template <class Traits> void skip_list<Traits>::_init_dummy() {
+    node_forward_guard head_guard(std::move(_construct_node(MAX_LEVEL)));
+    for (size_type i = 0; i <= MAX_LEVEL; ++i) {
+        head_guard.get()->_forward[i] = head_guard.get();
+    }
+    head_guard.get()->_backward = head_guard.get();
+    _dummy = head_guard.release();
+}
+
+template <class Traits>
+void skip_list<Traits>::_move_state(skip_list &&x) { // pre-require: _dummy is initialized (call _init_dummy())
+    using std::swap;
+    swap(_dummy, x._dummy);
+    swap(_max_level, x._max_level);
+    swap(_size, x._size);
+}
+
+template <class Traits> template <class Strategy> void skip_list<Traits>::_clone_tree(const skip_list &other) {
+    if (other.empty()) {
+        _init_dummy();
+        _max_level = 0;
+        _size = 0;
+        return;
+    }
+
+    copy_guard guard(_node_alloc);
+    node_forward_guard init_guard(std::move(_construct_node(MAX_LEVEL)));
+    guard.insert(other._dummy, init_guard.get());
+    init_guard.release();
+
+    node_ptr current_other = other._dummy->_forward[0];
+    while (current_other != other._dummy) {
+        if constexpr (Strategy::copy) {
+            node_forward_guard new_guard(std::move(_init_node(current_other->_value, current_other->_level)));
+            guard.insert(current_other, new_guard.get());
+            new_guard.release();
+        } else { // Strategy::move
+            node_forward_guard new_guard(
+                std::move(_init_node(std::move(const_cast<Node &>(*current_other)._value), current_other->_level)));
+            guard.insert(current_other, new_guard.get());
+            new_guard.release();
+        }
+        current_other = current_other->_forward[0];
+    }
+    // current_other is now other._dummy
+    do {
+        node_ptr new_node = guard.get_new_node(current_other);
+
+        for (size_type i = 0; i <= current_other->_level; ++i) {
+            new_node->_forward[i] = guard.get_new_node(current_other->_forward[i]);
+        }
+        new_node->_backward = guard.get_new_node(current_other->_backward);
+
+        current_other = current_other->_forward[0];
+    } while (current_other != other._dummy);
+
+    _dummy = guard.get_new_node(other._dummy);
+    guard.release();
+    _max_level = other._max_level;
+    _size = other._size;
+}
+
+template <class Traits> void skip_list<Traits>::_destroy_tree() noexcept {
+    node_ptr current = _dummy->_forward[0];
+    while (current != _dummy) {
+        node_ptr next = current->_forward[0];
+        _deallocate_node(current);
+        current = next;
+    }
+    _deallocate_dummy_node();
+}
+
+template <class Traits>
+template <class K>
+    requires IsTransparentlyComparable<K, typename Traits::key_type, typename Traits::key_compare>
+skip_list<Traits>::const_iterator skip_list<Traits>::_find_lower_bound(K &&key) const {
+    Node *current = _dummy;
+    for (size_type i = _max_level + 1; i > 0; --i) {
+        while (current->_forward[i - 1] != _dummy && _key_comp(current->_forward[i - 1]->_key(), key)) {
+            current = current->_forward[i - 1];
+        }
+    }
+    return const_iterator(current->_forward[0]);
+}
+
+template <class Traits>
+template <class K>
+    requires IsTransparentlyComparable<K, typename Traits::key_type, typename Traits::key_compare>
+skip_list<Traits>::const_iterator skip_list<Traits>::_find_upper_bound(K &&key) const {
+    Node *current = _dummy;
+    for (size_type i = _max_level + 1; i > 0; --i) {
+        while (current->_forward[i - 1] != _dummy && !_key_comp(key, current->_forward[i - 1]->_key())) {
+            current = current->_forward[i - 1];
+        }
+    }
+    return const_iterator(current->_forward[0]);
+}
+
+template <class Traits> skip_list<Traits>::node_ptr skip_list<Traits>::_extract_node(const_iterator position) {
+    auto predecessors = _find_predecessors(position._ptr->_key());
+    for (size_type i = 0; i <= position._ptr->_level; ++i) {
+        predecessors[i]->_forward[i] = position._ptr->_forward[i];
+    }
+    position._ptr->_forward[0]->_backward = position._ptr->_backward;
+    --_size;
+    return position._ptr;
+}
+
+template <class Traits>
+void skip_list<Traits>::_insert_node(Node *new_node, array<node_ptr, MAX_LEVEL + 1> &predecessors) noexcept {
+    if (new_node->_level > _max_level) {
+        std::fill(predecessors.begin() + _max_level + 1, predecessors.begin() + new_node->_level + 1, _dummy);
+        _max_level = new_node->_level;
+    }
+
+    for (size_type i = 0; i <= new_node->_level; ++i) {
+        new_node->_forward[i] = predecessors[i]->_forward[i];
+        predecessors[i]->_forward[i] = new_node;
+    }
+    new_node->_backward = predecessors[0];
+
+    new_node->_forward[0]->_backward = new_node;
+    ++_size;
+}
+
+template <class Traits>
+template <class... Args>
+    requires std::constructible_from<typename Traits::value_type, Args &&...>
+std::pair<typename skip_list<Traits>::iterator, bool> skip_list<Traits>::_emplace(size_type level, Args &&...args) {
+    value_type val(std::forward<Args>(args)...);
+    key_type key;
+    if constexpr (_IS_SET) {
+        key = val;
+    } else {
+        key = val.first;
+    }
+    auto predecessors = _find_predecessors(key);
+    if constexpr (!_MULTI) {
+        auto dup_check = predecessors[0] == _dummy ? _dummy->_backward : predecessors[0];
+        if (_is_duplicate(key, dup_check)) {
+            return {iterator(dup_check), false};
+        }
+    }
+    node_forward_guard new_node_guard(std::move(_init_node(std::move(val), level)));
+    _insert_node(new_node_guard.get(), predecessors);
+    return {iterator(new_node_guard.release()), true};
+}
+
+template <class Traits>
+template <class K, class... Args>
+    requires detail::TryEmplaceConstraint<skip_list<Traits>, K, Args...>
+skip_list<Traits>::iterator skip_list<Traits>::_try_emplace(K &&key, size_type level, Args &&...args) {
+    auto predecessors = _find_predecessors(key);
+
+    auto dup_check = predecessors[0] == _dummy ? _dummy->_backward : predecessors[0];
+    if (_is_duplicate(key, dup_check)) {
+        return iterator(dup_check);
+    }
+
+    node_forward_guard new_node_guard(
+        std::move(_init_node(std::piecewise_construct, std::forward_as_tuple(std::forward<K>(key)),
+                             std::forward_as_tuple(std::forward<Args>(args)...), level)));
+    _insert_node(new_node_guard.get(), predecessors);
+    return iterator(new_node_guard.release());
+}
+
+template <class Traits>
+template <class K, class M>
+    requires detail::InsertOrAssignConstraint<skip_list<Traits>, K, M>
+skip_list<Traits>::iterator skip_list<Traits>::_insert_or_assign(K &&key, M &&obj, size_type level) {
+    auto predecessors = _find_predecessors(key);
+    auto dup_check = predecessors[0] == _dummy ? _dummy->_backward : predecessors[0];
+    if (_is_duplicate(key, dup_check)) {
+        if constexpr (!std::is_const_v<typename std::remove_reference<M>::type>) {
+            dup_check->_value.second = std::forward<M>(obj);
+        } else {
+            dup_check->_value.second = obj;
+        }
+        return iterator(dup_check);
+    }
+    node_forward_guard new_node_guard(
+        std::move(_init_node(std::piecewise_construct, std::forward_as_tuple(std::forward<K>(key)),
+                             std::forward_as_tuple(std::forward<M>(obj)), level)));
+    _insert_node(new_node_guard.get(), predecessors);
+    return iterator(new_node_guard.release());
+}
+
+template <class Traits>
+skip_list<Traits>::skip_list(const key_compare &comp, const allocator_type &alloc)
+    : _node_alloc(alloc), _key_comp(comp) {
+    rng.seed(std::random_device{}());
+    _init_dummy();
+    _max_level = 0;
+    _size = 0;
+}
+
+template <class Traits>
+skip_list<Traits>::skip_list(const skip_list &other)
+    : _node_alloc(std::allocator_traits<allocator_type>::select_on_container_copy_construction(other._node_alloc)),
+      _key_comp(other._key_comp) {
+    _clone_tree<_strategy_copy>(other);
+}
+
+template <class Traits>
+skip_list<Traits>::skip_list(const skip_list &other, const std::type_identity_t<allocator_type> &alloc)
+    : _node_alloc(alloc), _key_comp(other._key_comp) {
+    _clone_tree<_strategy_copy>(other);
+}
+
+template <class Traits>
+skip_list<Traits>::skip_list(skip_list &&x)
+    : rng(std::move(x.rng)), coin_flip(std::move(x.coin_flip)), _max_level(0), _node_alloc(std::move(x._node_alloc)),
+      _size(0), _key_comp(std::move(x._key_comp)) {
+    _init_dummy();
+    _move_state(std::move(x));
+}
+
+template <class Traits>
+skip_list<Traits>::skip_list(skip_list &&x, const std::type_identity_t<allocator_type> &alloc)
+    : rng(std::move(x.rng)), coin_flip(std::move(x.coin_flip)), _max_level(0), _node_alloc(std::move(x._node_alloc)),
+      _size(0), _key_comp(std::move(x._key_comp)) {
+    if constexpr (!std::allocator_traits<allocator_type>::is_always_equal::value) {
+        if (_node_alloc != x._node_alloc) {
+            _clone_tree<_strategy_move>(x);
+            x.clear();
+            return;
+        }
+    }
+    _init_dummy();
+    _move_state(x);
+}
+
+template <class Traits> skip_list<Traits> &skip_list<Traits>::operator=(const skip_list &x) {
+    if (this == std::addressof(x)) {
+        return *this;
+    }
+
+    clear();
+    _key_comp = x._key_comp;
+    if constexpr (std::allocator_traits<allocator_type>::propagate_on_container_copy_assignment::value) {
+        if (this->_node_alloc != x._node_alloc) {
+            this->_node_alloc = x._node_alloc;
+        }
+    }
+    _clone_tree<_strategy_copy>(x);
+
+    return *this;
+}
+
+template <class Traits>
+skip_list<Traits> &
+skip_list<Traits>::operator=(skip_list &&x) noexcept(std::allocator_traits<allocator_type>::is_always_equal::value &&
+                                                     std::is_nothrow_move_assignable_v<key_compare>) {
+    if (this == std::addressof(x)) {
+        return *this;
+    }
+
+    if constexpr (!std::allocator_traits<allocator_type>::propagate_on_container_move_assignment::value &&
+                  !std::allocator_traits<allocator_type>::is_always_equal::value) { // POCMA
+        if (_node_alloc != x._node_alloc) {
+            clear();
+            _key_comp = std::move(x._key_comp);
+            _clone_tree<_strategy_move>(x);
+            x.clear();
+            return *this;
+        }
+    }
+    clear();
+    _key_comp = std::move(x._key_comp);
+    if constexpr (std::allocator_traits<allocator_type>::propagate_on_container_move_assignment::value) {
+        if (this->_node_alloc != x._node_alloc) {
+            this->_node_alloc = std::move(x._node_alloc);
+        }
+    }
+    _move_state(std::move(x));
+
+    return *this;
+}
+
+template <class Traits> skip_list<Traits>::~skip_list() noexcept {
+    _destroy_tree();
+}
+
+template <class Traits> skip_list<Traits>::iterator skip_list<Traits>::begin() noexcept {
+    return iterator(_dummy->_forward[0]);
+}
+
+template <class Traits> skip_list<Traits>::const_iterator skip_list<Traits>::cbegin() const noexcept {
+    return const_iterator(_dummy->_forward[0]);
+}
+
+template <class Traits> skip_list<Traits>::iterator skip_list<Traits>::end() noexcept {
+    return iterator(_dummy);
+}
+
+template <class Traits> skip_list<Traits>::const_iterator skip_list<Traits>::cend() const noexcept {
+    return const_iterator(_dummy);
+}
+
+template <class Traits> bool skip_list<Traits>::empty() const noexcept {
+    return _size == 0;
+}
+
+template <class Traits> skip_list<Traits>::size_type skip_list<Traits>::size() const noexcept {
+    return _size;
+}
+
+template <class Traits> skip_list<Traits>::size_type skip_list<Traits>::max_size() const noexcept {
+    return std::allocator_traits<allocator_type>::max_size(get_allocator());
+}
+
+template <class Traits> skip_list<Traits>::allocator_type skip_list<Traits>::get_allocator() const noexcept {
+    return allocator_type(_node_alloc);
+}
+
+template <class Traits>
+template <class... Args>
+    requires std::constructible_from<typename Traits::value_type, Args &&...>
+std::pair<typename skip_list<Traits>::iterator, bool> skip_list<Traits>::emplace(Args &&...args) {
+    size_type new_node_level = _random_level();
+    return _emplace(new_node_level, std::forward<Args>(args)...);
+}
+
+template <class Traits>
+template <class... Args>
+    requires std::constructible_from<typename Traits::value_type, Args &&...>
+skip_list<Traits>::iterator skip_list<Traits>::emplace_hint(const_iterator position, Args &&...args) {
+    value_type val(std::forward<Args>(args)...);
+    key_type key;
+    if constexpr (_IS_SET) {
+        key = val;
+    } else {
+        key = val.first;
+    }
+    size_type new_node_level = _random_level();
+    if (position != cbegin()) {
+        auto prev = std::prev(position);
+        if (!_key_comp(key, prev._ptr->_key()) && _key_comp(key, position._ptr->_key()) &&
+            prev._ptr->_level >= new_node_level) {
+            if (!_MULTI && key == prev._ptr->_key()) {
+                return iterator(prev._ptr);
+            }
+            array<node_ptr, MAX_LEVEL + 1> predecessors;
+            std::fill_n(predecessors.begin(), new_node_level + 1, prev._ptr);
+            node_forward_guard new_node_guard(std::move(_init_node(std::move(val), new_node_level)));
+            _insert_node(new_node_guard.get(), predecessors);
+            return iterator(new_node_guard.release());
+        }
+    }
+    return _emplace(new_node_level, std::move(val)).first;
+}
+
+template <class Traits>
+template <class InputIter>
+    requires std::input_iterator<InputIter>
+void skip_list<Traits>::insert(InputIter first, InputIter last) {
+    if (first == last)
+        return;
+
+    array<Node *, MAX_LEVEL + 1> predecessors;
+    predecessors.fill(_dummy);
+
+    key_type key;
+    for (; first != last; ++first) {
+        size_type new_node_level = _random_level();
+        if constexpr (_IS_SET) {
+            key = *first;
+        } else {
+            key = first->first;
+        }
+
+        if (predecessors[0] == _dummy || !_key_comp(key, predecessors[0]->_key())) {
+            _update_predecessors(key, predecessors);
+        } else {
+            predecessors = _find_predecessors(key);
+            std::fill(predecessors.begin() + _max_level + 1, predecessors.end(), _dummy);
+        }
+        if constexpr (!_MULTI) {
+            auto dup_check = predecessors[0] == _dummy ? _dummy->_backward : predecessors[0];
+            if (_is_duplicate(key, dup_check)) {
+                continue;
+            }
+        }
+        node_forward_guard new_node_guard(std::move(_init_node(*first, new_node_level)));
+        _insert_node(new_node_guard.get(), predecessors);
+        new_node_guard.release();
+    }
+} // benchmark 해볼 것.
+
+template <class Traits> skip_list<Traits>::node_type skip_list<Traits>::extract(const_iterator position) {
+    return node_type{_extract_node(position), get_allocator()};
+}
+
+template <class Traits> skip_list<Traits>::insert_return_type skip_list<Traits>::insert(node_type &&nh) {
+    auto predecessors = _find_predecessors(nh._ptr->_key());
+    if constexpr (!_MULTI) {
+        auto dup_check = predecessors[0] == _dummy ? _dummy->_backward : predecessors[0];
+        if (_is_duplicate(nh._ptr->_key(), dup_check)) {
+            return {iterator(dup_check), false, std::move(nh)};
+        }
+    }
+    _insert_node(nh._ptr, predecessors);
+    nh._ptr = nullptr;
+    return {iterator(predecessors[0]->_forward[0]), true, std::move(nh)};
+}
+
+template <class Traits> skip_list<Traits>::iterator skip_list<Traits>::insert(const_iterator position, node_type &&nh) {
+    size_type new_node_level = nh._ptr->_level;
+    key_type key = nh._ptr->_key();
+
+    if (position != cbegin()) {
+        auto prev = std::prev(position);
+        if (!_key_comp(key, prev._ptr->_key()) && _key_comp(key, position._ptr->_key()) &&
+            prev._ptr->_level >= new_node_level) {
+            if (!_MULTI && key == prev._ptr->_key()) {
+                return iterator(prev._ptr);
+            }
+            array<node_ptr, MAX_LEVEL + 1> predecessors;
+            _insert_node(nh._ptr, predecessors);
+            nh._ptr = nullptr;
+            return iterator(predecessors[0]->_forward[0]);
+        }
+    }
+    return insert(std::move(nh)).first;
+}
+
+template <class Traits>
+template <class K, class... Args>
+    requires detail::TryEmplaceConstraint<skip_list<Traits>, K, Args...>
+skip_list<Traits>::iterator skip_list<Traits>::try_emplace(K &&key, Args &&...args) {
+    size_type new_node_level = _random_level();
+    return _try_emplace(std::forward<K>(key), new_node_level, std::forward<Args>(args)...);
+}
+
+template <class Traits>
+template <class K, class... Args>
+    requires detail::TryEmplaceConstraint<skip_list<Traits>, K, Args...>
+skip_list<Traits>::iterator skip_list<Traits>::try_emplace(const_iterator position, K &&key, Args &&...args) {
+    size_type new_node_level = _random_level();
+
+    if (position != cbegin()) {
+        auto prev = std::prev(position);
+        if (!_key_comp(key, prev._ptr->_key()) && _key_comp(key, position._ptr->_key()) &&
+            prev._ptr->_level >= new_node_level) {
+            if (key == prev._ptr->_key()) { // not check _MULTI (try_emplace for map only)
+                return iterator(prev._ptr);
+            }
+            array<node_ptr, MAX_LEVEL + 1> predecessors;
+            std::fill(predecessors.begin(), new_node_level + 1, prev._ptr);
+            auto new_node_guard(
+                std::move(_init_node(std::piecewise_construct, std::forward_as_tuple(std::forward<K>(key)),
+                                     std::forward_as_tuple(std::forward<Args>(args)...), new_node_level)));
+            _insert_node(new_node_guard.get(), predecessors);
+            return iterator(new_node_guard.release());
+        }
+    }
+
+    return _try_emplace(std::forward<K>(key), new_node_level, std::forward<Args>(args)...);
+}
+
+template <class Traits>
+template <class K, class M>
+    requires detail::InsertOrAssignConstraint<skip_list<Traits>, K, M>
+skip_list<Traits>::iterator skip_list<Traits>::insert_or_assign(K &&key, M &&obj) {
+    size_type new_node_level = _random_level();
+    return _insert_or_assign(std::forward<K>(key), std::forward<M>(obj), new_node_level);
+}
+
+template <class Traits>
+template <class K, class M>
+    requires detail::InsertOrAssignConstraint<skip_list<Traits>, K, M>
+skip_list<Traits>::iterator skip_list<Traits>::insert_or_assign(const_iterator position, K &&key, M &&obj) {
+    size_type new_node_level = _random_level();
+    if (position != cbegin()) {
+        auto prev = std::prev(position);
+        if (!_key_comp(key, prev._ptr->_key()) && _key_comp(key, position._ptr->_key()) &&
+            prev._ptr->_level >= new_node_level) {
+            if (key == prev._ptr->_key()) { // not check _MULTI (insert_or_assign for map only)
+                if constexpr (!std::is_const_v<typename std::remove_reference<M>::type>) {
+                    prev._ptr->_value.second = std::forward<M>(obj);
+                } else {
+                    prev._ptr->_value.second = obj;
+                }
+                return iterator(prev._ptr);
+            }
+        }
+    }
+    return _insert_or_assign(std::forward<K>(key), std::forward<M>(obj), new_node_level);
+}
+
+template <class Traits> skip_list<Traits>::iterator skip_list<Traits>::erase(const_iterator position) {
+    auto next_it = iterator(position._ptr->_forward[0]);
+
+    _deallocate_node(_extract_node(position));
+    return next_it;
+}
+
+template <class Traits>
+skip_list<Traits>::iterator skip_list<Traits>::erase(const_iterator first, const_iterator last) {
+    while (first != last) {
+        first = erase(first);
+    }
+    return iterator(first._ptr);
+}
+
+template <class Traits>
+void skip_list<Traits>::swap(skip_list &x) noexcept(std::allocator_traits<allocator_type>::is_always_equal::value &&
+                                                    std::is_nothrow_swappable_v<key_compare>) {
+    using std::swap;
+    if constexpr (std::allocator_traits<typename Traits::allocator_type>::propagate_on_container_swap::value) {
+        swap(_node_alloc, x._node_alloc);
+    }
+    swap(rng, x.rng);
+    swap(coin_flip, x.coin_flip);
+    swap(_max_level, x._max_level);
+    swap(_dummy, x._dummy);
+    swap(_size, x._size);
+    swap(_key_comp, x._key_comp);
+}
+
+template <class Traits> void skip_list<Traits>::clear() noexcept {
+    node_ptr current = _dummy->_forward[0];
+    while (current != _dummy) {
+        node_ptr next = current->_forward[0];
+        _deallocate_node(current);
+        current = next;
+    }
+    for (size_type i = 0; i <= _max_level; ++i) {
+        _dummy->_forward[i] = _dummy;
+    }
+    _dummy->_backward = _dummy;
+    _max_level = 0;
+    _size = 0;
+}
+
+// template <class Traits>
+// template <class SourceTree>
+// requires IsMergeable<Traits, SourceTree>
+// void skip_list<Traits>::merge(SourceTree &source) {}
+
+template <class Traits> void skip_list<Traits>::merge(skip_list &source) {
+    if (this == std::addressof(source) || source.empty()) {
+        return;
+    }
+    array<Node *, MAX_LEVEL + 1> predecessors;
+    predecessors.fill(_dummy);
+
+    auto end = source.end();
+    for (auto it = source.begin(); it != end;) {
+        auto next_it = std::next(it);
+        key_type key = it._ptr->_key();
+        size_type level = it._ptr->_level;
+        _update_predecessors(key, predecessors);
+        if constexpr (!_MULTI) {
+            auto dup_check = predecessors[0] == _dummy ? _dummy->_backward : predecessors[0];
+            if (_is_duplicate(key, dup_check)) {
+                ++it;
+                continue;
+            }
+        }
+        _insert_node(source._extract_node(it), predecessors);
+        it = next_it;
+    }
+}
+
+template <class Traits> skip_list<Traits>::key_compare skip_list<Traits>::key_comp() const {
+    return _key_comp;
+}
+
+template <class Traits> skip_list<Traits>::value_compare skip_list<Traits>::value_comp() const {
+    return value_compare(_key_comp);
+}
+
+template <class Traits>
+template <class K>
+    requires IsTransparentlyComparable<K, typename Traits::key_type, typename Traits::key_compare>
+skip_list<Traits>::iterator skip_list<Traits>::find(K &&key) {
+    const_iterator cit = std::as_const(*this).find(std::forward<K>(key));
+    return iterator(cit._ptr);
+}
+
+template <class Traits>
+template <class K>
+    requires IsTransparentlyComparable<K, typename Traits::key_type, typename Traits::key_compare>
+skip_list<Traits>::const_iterator skip_list<Traits>::find(K &&key) const {
+    const_iterator it = _find_lower_bound(std::forward<K>(key));
+    value_compare value_comp = this->value_comp();
+    if (it != cend() && !value_comp(key, *it) && !value_comp(*it, key)) {
+        return it;
+    }
+    return cend();
+}
+
+template <class Traits>
+template <class K>
+    requires IsTransparentlyComparable<K, typename Traits::key_type, typename Traits::key_compare>
+skip_list<Traits>::size_type skip_list<Traits>::count(K &&key) const {
+    if constexpr (_MULTI) {
+        auto range = equal_range(std::forward<K>(key));
+        return std::distance(range.first, range.second);
+    } else {
+        return find(std::forward<K>(key)) != cend() ? 1 : 0;
+    }
+}
+
+template <class Traits>
+template <class K>
+    requires IsTransparentlyComparable<K, typename Traits::key_type, typename Traits::key_compare>
+bool skip_list<Traits>::contains(K &&key) const {
+    return find(std::forward<K>(key)) != cend();
+}
+
+template <class Traits>
+template <class K>
+    requires IsTransparentlyComparable<K, typename Traits::key_type, typename Traits::key_compare>
+skip_list<Traits>::iterator skip_list<Traits>::lower_bound(K &&key) {
+    const_iterator cit = _find_lower_bound(std::forward<K>(key));
+    return iterator(cit._ptr);
+}
+
+template <class Traits>
+template <class K>
+    requires IsTransparentlyComparable<K, typename Traits::key_type, typename Traits::key_compare>
+skip_list<Traits>::const_iterator skip_list<Traits>::lower_bound(K &&key) const {
+    return _find_lower_bound(std::forward<K>(key));
+}
+
+template <class Traits>
+template <class K>
+    requires IsTransparentlyComparable<K, typename Traits::key_type, typename Traits::key_compare>
+skip_list<Traits>::iterator skip_list<Traits>::upper_bound(K &&key) {
+    const_iterator cit = _find_upper_bound(std::forward<K>(key));
+    return iterator(cit._ptr);
+}
+
+template <class Traits>
+template <class K>
+    requires IsTransparentlyComparable<K, typename Traits::key_type, typename Traits::key_compare>
+skip_list<Traits>::const_iterator skip_list<Traits>::upper_bound(K &&key) const {
+    return _find_upper_bound(std::forward<K>(key));
+}
+
+template <class Traits>
+template <class K>
+    requires IsTransparentlyComparable<K, typename Traits::key_type, typename Traits::key_compare>
+std::pair<typename skip_list<Traits>::iterator, typename skip_list<Traits>::iterator>
+skip_list<Traits>::equal_range(K &&key) {
+    auto lower = _find_lower_bound(std::forward<K>(key));
+    auto upper = _find_upper_bound(std::forward<K>(key));
+    return {iterator(lower._ptr), iterator(upper._ptr)};
+}
+
+template <class Traits>
+template <class K>
+    requires IsTransparentlyComparable<K, typename Traits::key_type, typename Traits::key_compare>
+std::pair<typename skip_list<Traits>::const_iterator, typename skip_list<Traits>::const_iterator>
+skip_list<Traits>::equal_range(K &&key) const {
+    return {_find_lower_bound(std::forward<K>(key)), _find_upper_bound(std::forward<K>(key))};
+}
+
+} // namespace j

--- a/modules/datastructures/Tree/Base/skip_list.cppm
+++ b/modules/datastructures/Tree/Base/skip_list.cppm
@@ -1,0 +1,142 @@
+/*
+ * @ Created by jaehyung409 on 25. 9. 16..
+ * @ Copyright (c) 2025 jaehyung409 
+ * This software is licensed under the MIT License. 
+ */
+
+module;
+#include <utility>
+#include <memory>
+#include <functional>
+#include <random>
+
+export module j:skip_list;
+
+import :traits;
+import :vector;
+
+namespace j {
+export template <class Value, class Compare, class Allocator>
+class skip_list : private value_compare_traits<
+                     typename key_traits<Value>::key_type,
+                     Value,
+                     Compare,
+                     key_traits<Value>>::value_compare {
+public:
+    using value_type = Value;
+    using key_type   = typename key_traits<Value>::key_type;
+    using mapped_type = typename key_traits<Value>::mapped_type; // for map, multimap
+    using key_compare = Compare;
+    using value_compare = typename value_compare_traits<key_type, value_type, Compare, key_traits<Value>>::value_compare; // EBO
+    using allocator_type         = Allocator;
+    using pointer                = typename std::allocator_traits<Allocator>::pointer;
+    using const_pointer          = typename std::allocator_traits<Allocator>::const_pointer;
+    using reference              = value_type&;
+    using const_reference        = const value_type&;
+    using size_type = typename std::allocator_traits<Allocator>::size_type;
+    using difference_type = typename std::allocator_traits<Allocator>::difference_type;
+    using iterator = /* not yet */
+    using const_iterator = /* not yet */
+    using reverse_iterator       = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+    struct node_type;
+    using insert_return_type     = std::pair<iterator, node_type>; // for set, map
+
+    skip_list() : skip_list(Compare()) {}
+    explicit skip_list(const Compare& comp, const Allocator& alloc = Allocator());
+    template<class InputIter>
+    requires std::input_iterator<InputIter>
+    skip_list(InputIter first, InputIter last, const Compare& comp = Compare(), const Allocator& alloc = Allocator());
+    skip_list(const skip_list& other);
+    skip_list(const skip_list& other, const Allocator& alloc);
+    skip_list(skip_list&& other);
+    skip_list(skip_list&& other, const Allocator& alloc);
+    skip_list(std::initializer_list<value_type> il, const Compare& comp = Compare(), const Allocator& alloc = Allocator());
+    skip_list& operator=(const skip_list& x);
+    skip_list& operator=(skip_list&& x);
+    skip_list& operator=(std::initializer_list<value_type> il);
+    ~skip_list();
+    allocator_type get_allocator() const noexcept;
+
+    iterator begin() noexcept;
+    const_iterator begin() const noexcept;
+    iterator end() noexcept;
+    const_iterator end() const noexcept;
+    reverse_iterator rbegin() noexcept;
+    const_reverse_iterator rbegin() const noexcept;
+    reverse_iterator rend() noexcept;
+    const_reverse_iterator rend() const noexcept;
+
+    const_iterator cbegin() const noexcept;
+    const_iterator cend() const noexcept;
+    const_reverse_iterator crbegin() const noexcept;
+    const_reverse_iterator crend() const noexcept;
+
+    [[nodiscard]] bool empty() const noexcept;
+    [[nodiscard]] size_type size() const noexcept;
+    [[nodiscard]] size_type max_size() const noexcept;
+
+
+    auto lower_bound(const key_type& key) const;
+    template<class... Args>
+    auto emplace(const_iterator position, Args&&... args);
+    auto erase(const_iterator position);
+    auto insert(const iterator position, node_type node);
+    auto extract(const_iterator position);
+    void clear();
+    void swap(skip_list& other) noexcept;
+
+private:
+    struct _skip_list_node;
+    using Node = _skip_list_node;
+    using node_allocator_type = typename std::allocator_traits<Allocator>::template rebind_alloc<Node>;
+    mutable std::mt19937 rng;
+    mutable std::bernoulli_distribution coin_flip{0.5};
+
+    static const size_type MAX_LEVEL = 32;
+    Node* _header; // header node
+    Node* _tail;   // tail node
+    node_allocator_type _node_alloc;
+    size_type _size;
+
+    size_type _random_level() const {
+        size_type level = 0;
+        while (coin_flip(rng)) {
+            ++level;
+        }
+        return level;
+    }
+    void _find_predecessors(const key_type& key, vector<Node*>& predecessors) const; // 아직 구조를 확정 못함.
+};
+
+// non-member functions will be added later
+
+template <class Value, class Compare, class Allocator>
+struct skip_list<Value, Compare, Allocator>::_skip_list_node {
+    friend skip_list;
+    friend iterator;
+    friend const_iterator;
+private:
+    value_type _value;
+    size_type _level;
+    vector<Node*> _forward; // forward[i] = next node at level i
+    Node* _backward;
+
+    explicit _skip_list_node(value_type& value) : _value(value) {
+        _level = _random_level();
+        _forward = vector<Node*>(_level + 1, nullptr);
+        _backward = nullptr;
+    }
+    ~_skip_list_node() = default; // destructor will be defined later
+};
+template <class Value, class Compare, class Allocator>
+template <bool IsConst>
+class skip_list<Value, Compare, Allocator>::_iterator_impl {};
+
+template <class Value, class Compare, class Allocator>
+struct skip_list<Value, Compare, Allocator>::node_type {};
+}
+
+namespace j {
+
+}

--- a/modules/datastructures/Tree/Base/skip_list.cppm
+++ b/modules/datastructures/Tree/Base/skip_list.cppm
@@ -1038,7 +1038,7 @@ void skip_list<Traits>::insert(InputIter first, InputIter last) {
         _insert_node(new_node_guard.get(), predecessors);
         new_node_guard.release();
     }
-} // benchmark 해볼 것.
+} // Should benchmark.
 
 template <class Traits> skip_list<Traits>::node_type skip_list<Traits>::extract(const_iterator position) {
     return node_type{_extract_node(position), get_allocator()};

--- a/modules/datastructures/Tree/Base/skip_list.cppm
+++ b/modules/datastructures/Tree/Base/skip_list.cppm
@@ -396,8 +396,8 @@ template <class Traits> class skip_list<Traits>::_const_iterator {
 };
 
 template <class Traits>
-struct skip_list<Traits>::node_type { // node hanlder 구현이
-                                      // 잘못됨.https://en.cppreference.com/w/cpp/container/node_handle.html
+struct skip_list<Traits>::node_type { // Node handler implementation is incorrect.
+                                      // https://en.cppreference.com/w/cpp/container/node_handle.html
     friend skip_list;
 
   public:

--- a/modules/datastructures/Tree/Map/map.cppm
+++ b/modules/datastructures/Tree/Map/map.cppm
@@ -1,0 +1,7 @@
+/*
+ * @ Created by jaehyung409 on 25. 9. 25..
+ * @ Copyright (c) 2025 jaehyung409
+ * This software is licensed under the MIT License.
+ */
+
+export module j:map;

--- a/modules/datastructures/Tree/Set/set.cppm
+++ b/modules/datastructures/Tree/Set/set.cppm
@@ -1,0 +1,1349 @@
+/*
+ * @ Created by jaehyung409 on 25. 9. 25..
+ * @ Copyright (c) 2025 jaehyung409
+ * This software is licensed under the MIT License.
+ */
+
+module;
+#include <algorithm>
+#include <functional>
+
+export module j:set;
+
+import :traits;
+import :tree_selector;
+
+namespace j {
+export template <class Key, class Compare, class Allocator, class TreeSelector = use_skip_list> class multiset;
+
+export template <class Key, class Compare = std::less<Key>, class Allocator = std::allocator<Key>,
+                 class TreeSelector = use_skip_list>
+class set {
+  private:
+    using traits = set_traits<Key, Compare, Allocator>;
+    using tree_type = select_tree_t<traits, TreeSelector>;
+    tree_type _tree;
+
+  public:
+    using key_type = typename traits::key_type;
+    using key_compare = typename traits::key_compare;
+    using value_type = typename traits::value_type;
+    using value_compare = typename traits::value_compare;
+    using allocator_type = typename traits::allocator_type;
+    using pointer = typename std::allocator_traits<Allocator>::pointer;
+    using const_pointer = typename std::allocator_traits<Allocator>::const_pointer;
+    using reference = value_type &;
+    using const_reference = const value_type &;
+    using size_type = typename tree_type::size_type;
+    using difference_type = typename tree_type::difference_type;
+    using iterator = typename tree_type::iterator;
+    using const_iterator = typename tree_type::const_iterator;
+    using reverse_iterator = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+    using node_type = typename tree_type::node_type;
+    using insert_return_type = typename tree_type::insert_return_type;
+
+    // construct/copy/destroy
+    set() : set(Compare()) {}
+    explicit set(const Compare &comp, const Allocator &alloc = Allocator());
+    template <class InputIter>
+        requires std::input_iterator<InputIter> && std::constructible_from<value_type, std::iter_reference_t<InputIter>>
+    set(InputIter first, InputIter last, const Compare &comp = Compare(), const Allocator &alloc = Allocator());
+    set(const set &x) = default; // Rule of zero
+    set(set &&x) = default;      // Rule of zero
+    explicit set(const Allocator &alloc);
+    set(const set &x, const std::type_identity_t<Allocator> &alloc);
+    set(set &&x, const std::type_identity_t<Allocator> &alloc);
+    set(std::initializer_list<value_type> il, const Compare &comp = Compare(), const Allocator &alloc = Allocator());
+    template <class InputIter>
+        requires std::input_iterator<InputIter> && std::constructible_from<value_type, std::iter_reference_t<InputIter>>
+    set(InputIter first, InputIter last, const Allocator &a) : set(first, last, Compare(), a) {}
+    set(std::initializer_list<value_type> il, const Allocator &a) : set(il, Compare(), a) {}
+    ~set() = default; // Rule of zero
+
+    set &operator=(const set &x) = default; // Rule of zero
+    set &operator=(set &&x) = default;      // Rule of zero (noexcept depends on tree_type, compiler can optimize it)
+    set &operator=(std::initializer_list<value_type> il);
+    [[nodiscard]] allocator_type get_allocator() const noexcept;
+
+    // iterators
+    [[nodiscard]] iterator begin() noexcept;
+    [[nodiscard]] const_iterator begin() const noexcept;
+    [[nodiscard]] iterator end() noexcept;
+    [[nodiscard]] const_iterator end() const noexcept;
+
+    [[nodiscard]] reverse_iterator rbegin() noexcept;
+    [[nodiscard]] const_reverse_iterator rbegin() const noexcept;
+    [[nodiscard]] reverse_iterator rend() noexcept;
+    [[nodiscard]] const_reverse_iterator rend() const noexcept;
+
+    [[nodiscard]] const_iterator cbegin() const noexcept;
+    [[nodiscard]] const_iterator cend() const noexcept;
+    [[nodiscard]] const_reverse_iterator crbegin() const noexcept;
+    [[nodiscard]] const_reverse_iterator crend() const noexcept;
+
+    // capacity
+    [[nodiscard]] bool empty() const noexcept;
+    [[nodiscard]] size_type size() const noexcept;
+    [[nodiscard]] size_type max_size() const noexcept;
+
+    // modifiers
+    template <class... Args>
+        requires std::constructible_from<value_type, Args &&...>
+    std::pair<iterator, bool> emplace(Args &&...args);
+    template <class... Args>
+        requires std::constructible_from<value_type, Args &&...>
+    iterator emplace_hint(const_iterator position, Args &&...args);
+    std::pair<iterator, bool> insert(const value_type &x);
+    std::pair<iterator, bool> insert(value_type &&x);
+    template <class K>
+        requires std::constructible_from<value_type, K &&>
+    std::pair<iterator, bool> insert(K &&x);
+    iterator insert(const_iterator position, const value_type &x);
+    iterator insert(const_iterator position, value_type &&x);
+    template <class K>
+        requires std::constructible_from<value_type, K &&>
+    iterator insert(const_iterator position, K &&x);
+    template <class InputIter>
+        requires std::input_iterator<InputIter>
+    void insert(InputIter first, InputIter last);
+    void insert(std::initializer_list<value_type> il);
+
+    node_type extract(const_iterator position);
+    node_type extract(const key_type &x);
+    template <class K>
+        requires(IsTransparentlyComparable<K, key_type, key_compare> &&
+                 !std::is_convertible_v<std::remove_cvref_t<K>, iterator> &&
+                 !std::is_convertible_v<std::remove_cvref_t<K>, const_iterator>)
+    node_type extract(K &&x);
+    insert_return_type insert(node_type &&nh);
+    iterator insert(const_iterator hint, node_type &&nh);
+
+    iterator erase(iterator position)
+        requires(!std::same_as<iterator, const_iterator>);
+    iterator erase(const_iterator position);
+    size_type erase(const key_type &x);
+    template <class K>
+        requires(IsTransparentlyComparable<K, key_type, key_compare> &&
+                 !std::is_convertible_v<std::remove_cvref_t<K>, iterator> &&
+                 !std::is_convertible_v<std::remove_cvref_t<K>, const_iterator>)
+    size_type erase(K &&x);
+    iterator erase(const_iterator first, const_iterator last);
+    void swap(set &x) noexcept(std::allocator_traits<Allocator>::is_always_equal::value &&
+                               std::is_nothrow_swappable_v<Compare>);
+    void clear() noexcept;
+
+    // Later, we will implement heterogeneous merge for different select_tree_t types.
+    // For now, we only implement merge for the same select_tree_t type.
+    // Also, we only implement fast-path only (same compare).
+    // _tree is private, so we need to implementation `merge(source)` in base tree class. (enhancement)
+    template <class C2> void merge(set<Key, C2, Allocator, TreeSelector> &source);
+    template <class C2> void merge(set<Key, C2, Allocator, TreeSelector> &&source);
+    template <class C2> void merge(multiset<Key, C2, Allocator, TreeSelector> &source);
+    template <class C2> void merge(multiset<Key, C2, Allocator, TreeSelector> &&source);
+
+    // observers
+    [[nodiscard]] key_compare key_comp() const;
+    [[nodiscard]] value_compare value_comp() const;
+
+    // set operations
+    [[nodiscard]] iterator find(const key_type &x);
+    [[nodiscard]] const_iterator find(const key_type &x) const;
+    template <class K>
+        requires IsTransparentlyComparable<K, key_type, key_compare>
+    [[nodiscard]] iterator find(const K &x);
+    template <class K>
+        requires IsTransparentlyComparable<K, key_type, key_compare>
+    [[nodiscard]] const_iterator find(const K &x) const;
+
+    [[nodiscard]] size_type count(const key_type &x) const;
+    template <class K>
+        requires IsTransparentlyComparable<K, key_type, key_compare>
+    [[nodiscard]] size_type count(const K &x) const;
+
+    [[nodiscard]] bool contains(const key_type &x) const;
+    template <class K>
+        requires IsTransparentlyComparable<K, key_type, key_compare>
+    [[nodiscard]] bool contains(const K &x) const;
+
+    [[nodiscard]] iterator lower_bound(const key_type &x);
+    [[nodiscard]] const_iterator lower_bound(const key_type &x) const;
+    template <class K>
+        requires IsTransparentlyComparable<K, key_type, key_compare>
+    [[nodiscard]] iterator lower_bound(const K &x);
+    template <class K>
+        requires IsTransparentlyComparable<K, key_type, key_compare>
+    [[nodiscard]] const_iterator lower_bound(const K &x) const;
+
+    [[nodiscard]] iterator upper_bound(const key_type &x);
+    [[nodiscard]] const_iterator upper_bound(const key_type &x) const;
+    template <class K>
+        requires IsTransparentlyComparable<K, key_type, key_compare>
+    [[nodiscard]] iterator upper_bound(const K &x);
+    template <class K>
+        requires IsTransparentlyComparable<K, key_type, key_compare>
+    [[nodiscard]] const_iterator upper_bound(const K &x) const;
+
+    [[nodiscard]] std::pair<iterator, iterator> equal_range(const key_type &x);
+    [[nodiscard]] std::pair<const_iterator, const_iterator> equal_range(const key_type &x) const;
+    template <class K>
+        requires IsTransparentlyComparable<K, key_type, key_compare>
+    [[nodiscard]] std::pair<iterator, iterator> equal_range(const K &x);
+    template <class K>
+        requires IsTransparentlyComparable<K, key_type, key_compare>
+    [[nodiscard]] std::pair<const_iterator, const_iterator> equal_range(const K &x) const;
+};
+
+template <class InputIter, class Compare = std::less<typename std::iterator_traits<InputIter>::value_type>,
+          class Allocator = std::allocator<typename std::iterator_traits<InputIter>::value_type>>
+set(InputIter, InputIter, Compare = Compare(), Allocator = Allocator())
+    -> set<typename std::iterator_traits<InputIter>::value_type, Compare, Allocator>;
+
+template <class Key, class Compare = std::less<Key>, class Allocator = std::allocator<Key>>
+set(std::initializer_list<Key>, Compare = Compare(), Allocator = Allocator()) -> set<Key, Compare, Allocator>;
+
+template <class InputIter, class Allocator>
+set(InputIter, InputIter, Allocator) -> set<typename std::iterator_traits<InputIter>::value_type,
+                                            std::less<typename std::iterator_traits<InputIter>::value_type>, Allocator>;
+
+template <class Key, class Allocator> set(std::initializer_list<Key>, Allocator) -> set<Key, std::less<Key>, Allocator>;
+
+export template <class Key, class Compare, class Allocator, class TreeSelector>
+bool operator==(const set<Key, Compare, Allocator, TreeSelector> &lhs,
+                const set<Key, Compare, Allocator, TreeSelector> &rhs) {
+    return std::equal(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
+}
+
+export template <class Key, class Compare, class Allocator, class TreeSelector>
+auto operator<=>(const set<Key, Compare, Allocator, TreeSelector> &lhs,
+                 const set<Key, Compare, Allocator, TreeSelector> &rhs) -> std::strong_ordering {
+    return std::lexicographical_compare_three_way(lhs.begin(), lhs.end(), rhs.begin(), rhs.end(),
+                                                  std::compare_three_way{});
+}
+
+export template <class Key, class Compare, class Allocator, class TreeSelector>
+void swap(set<Key, Compare, Allocator, TreeSelector> &x,
+          set<Key, Compare, Allocator, TreeSelector> &y) noexcept(noexcept(x.swap(y))) {
+    x.swap(y);
+}
+
+export template <class Key, class Compare, class Allocator, class TreeSelector, class Pred>
+set<Key, Compare, Allocator, TreeSelector>::size_type erase_if(set<Key, Compare, Allocator, TreeSelector> &c,
+                                                               Pred pred) {
+    auto it = std::remove_if(c.begin(), c.end(), pred);
+    auto r = c.end() - it;
+    c.erase(it, c.end());
+    return r;
+}
+} // namespace j
+
+namespace j {
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::set(const Compare &comp, const Allocator &alloc) : _tree(comp, alloc) {}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class InputIter>
+    requires std::input_iterator<InputIter> &&
+             std::constructible_from<typename set_traits<Key, Compare, Allocator>::value_type,
+                                     std::iter_reference_t<InputIter>>
+set<Key, Compare, Allocator, TreeSelector>::set(InputIter first, InputIter last, const Compare &comp,
+                                                const Allocator &alloc)
+    : _tree(comp, alloc) {
+    _tree.insert(first, last);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::set(const Allocator &alloc) : _tree(Compare(), alloc) {}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::set(const set &x, const std::type_identity_t<Allocator> &alloc)
+    : _tree(x._tree, alloc) {}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::set(set &&x, const std::type_identity_t<Allocator> &alloc)
+    : _tree(std::move(x._tree), alloc) {}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::set(std::initializer_list<value_type> il, const Compare &comp,
+                                                const Allocator &alloc)
+    : _tree(comp, alloc) {
+    _tree.insert(il.begin(), il.end());
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector> &
+set<Key, Compare, Allocator, TreeSelector>::operator=(std::initializer_list<value_type> il) {
+    _tree.clear();
+    _tree.insert(il.begin(), il.end());
+    return *this;
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::allocator_type
+set<Key, Compare, Allocator, TreeSelector>::get_allocator() const noexcept {
+    return _tree.get_allocator();
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::iterator set<Key, Compare, Allocator, TreeSelector>::begin() noexcept {
+    return _tree.begin();
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::const_iterator
+set<Key, Compare, Allocator, TreeSelector>::begin() const noexcept {
+    return _tree.cbegin();
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::iterator set<Key, Compare, Allocator, TreeSelector>::end() noexcept {
+    return _tree.end();
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::const_iterator
+set<Key, Compare, Allocator, TreeSelector>::end() const noexcept {
+    return _tree.cend();
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::reverse_iterator
+set<Key, Compare, Allocator, TreeSelector>::rbegin() noexcept {
+    return reverse_iterator(end());
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::const_reverse_iterator
+set<Key, Compare, Allocator, TreeSelector>::rbegin() const noexcept {
+    return const_reverse_iterator(end());
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::reverse_iterator
+set<Key, Compare, Allocator, TreeSelector>::rend() noexcept {
+    return reverse_iterator(begin());
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::const_reverse_iterator
+set<Key, Compare, Allocator, TreeSelector>::rend() const noexcept {
+    return const_reverse_iterator(begin());
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::const_iterator
+set<Key, Compare, Allocator, TreeSelector>::cbegin() const noexcept {
+    return _tree.cbegin();
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::const_iterator
+set<Key, Compare, Allocator, TreeSelector>::cend() const noexcept {
+    return _tree.cend();
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::const_reverse_iterator
+set<Key, Compare, Allocator, TreeSelector>::crbegin() const noexcept {
+    return const_reverse_iterator(cend());
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::const_reverse_iterator
+set<Key, Compare, Allocator, TreeSelector>::crend() const noexcept {
+    return const_reverse_iterator(cbegin());
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+bool set<Key, Compare, Allocator, TreeSelector>::empty() const noexcept {
+    return _tree.empty();
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::size_type
+set<Key, Compare, Allocator, TreeSelector>::size() const noexcept {
+    return _tree.size();
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::size_type
+set<Key, Compare, Allocator, TreeSelector>::max_size() const noexcept {
+    return _tree.max_size();
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class... Args>
+    requires std::constructible_from<typename set_traits<Key, Compare, Allocator>::value_type, Args &&...>
+std::pair<typename set<Key, Compare, Allocator, TreeSelector>::iterator, bool>
+set<Key, Compare, Allocator, TreeSelector>::emplace(Args &&...args) {
+    return _tree.emplace(std::forward<Args>(args)...);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class... Args>
+    requires std::constructible_from<typename set_traits<Key, Compare, Allocator>::value_type, Args &&...>
+set<Key, Compare, Allocator, TreeSelector>::iterator
+set<Key, Compare, Allocator, TreeSelector>::emplace_hint(const_iterator position, Args &&...args) {
+    return _tree.emplace_hint(position, std::forward<Args>(args)...);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+std::pair<typename set<Key, Compare, Allocator, TreeSelector>::iterator, bool>
+set<Key, Compare, Allocator, TreeSelector>::insert(const value_type &x) {
+    return _tree.emplace(x);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+std::pair<typename set<Key, Compare, Allocator, TreeSelector>::iterator, bool>
+set<Key, Compare, Allocator, TreeSelector>::insert(value_type &&x) {
+    return _tree.emplace(std::move(x));
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class K>
+    requires std::constructible_from<typename set_traits<Key, Compare, Allocator>::value_type, K &&>
+std::pair<typename set<Key, Compare, Allocator, TreeSelector>::iterator, bool>
+set<Key, Compare, Allocator, TreeSelector>::insert(K &&x) {
+    return _tree.emplace(std::forward<K>(x));
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::iterator
+set<Key, Compare, Allocator, TreeSelector>::insert(const_iterator position, const value_type &x) {
+    return _tree.emplace_hint(position, x);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::iterator
+set<Key, Compare, Allocator, TreeSelector>::insert(const_iterator position, value_type &&x) {
+    return _tree.emplace_hint(position, std::move(x));
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class K>
+    requires std::constructible_from<typename set_traits<Key, Compare, Allocator>::value_type, K &&>
+set<Key, Compare, Allocator, TreeSelector>::iterator
+set<Key, Compare, Allocator, TreeSelector>::insert(const_iterator position, K &&x) {
+    return _tree.emplace_hint(position, std::forward<K>(x));
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class InputIter>
+    requires std::input_iterator<InputIter>
+void set<Key, Compare, Allocator, TreeSelector>::insert(InputIter first, InputIter last) {
+    return _tree.insert(first, last);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+void set<Key, Compare, Allocator, TreeSelector>::insert(std::initializer_list<value_type> il) {
+    return _tree.insert(il.begin(), il.end());
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::node_type
+set<Key, Compare, Allocator, TreeSelector>::extract(const_iterator position) {
+    return _tree.extract(position);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::node_type
+set<Key, Compare, Allocator, TreeSelector>::extract(const key_type &x) {
+    return _tree.extract(x);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class K>
+    requires(
+        IsTransparentlyComparable<K, typename set_traits<Key, Compare, Allocator>::key_type,
+                                  typename set_traits<Key, Compare, Allocator>::key_compare> &&
+        !std::is_convertible_v<std::remove_cvref_t<K>,
+                               typename select_tree_t<set_traits<Key, Compare, Allocator>, TreeSelector>::iterator> &&
+        !std::is_convertible_v<std::remove_cvref_t<K>, typename select_tree_t<set_traits<Key, Compare, Allocator>,
+                                                                              TreeSelector>::const_iterator>)
+set<Key, Compare, Allocator, TreeSelector>::node_type set<Key, Compare, Allocator, TreeSelector>::extract(K &&x) {
+    return _tree.extract(std::forward<K>(x));
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::insert_return_type
+set<Key, Compare, Allocator, TreeSelector>::insert(node_type &&nh) {
+    return _tree.insert(std::move(nh));
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::iterator
+set<Key, Compare, Allocator, TreeSelector>::insert(const_iterator hint, node_type &&nh) {
+    return _tree.insert(hint, std::move(nh));
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::iterator
+set<Key, Compare, Allocator, TreeSelector>::erase(iterator position)
+    requires(!std::same_as<typename select_tree_t<set_traits<Key, Compare, Allocator>, TreeSelector>::iterator,
+                           typename select_tree_t<set_traits<Key, Compare, Allocator>, TreeSelector>::const_iterator>)
+{
+    return _tree.erase(position);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::iterator
+set<Key, Compare, Allocator, TreeSelector>::erase(const_iterator position) {
+    return _tree.erase(position);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::size_type
+set<Key, Compare, Allocator, TreeSelector>::erase(const key_type &x) {
+    return _tree.erase(x);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class K>
+    requires(
+        IsTransparentlyComparable<K, typename set_traits<Key, Compare, Allocator>::key_type,
+                                  typename set_traits<Key, Compare, Allocator>::key_compare> &&
+        !std::is_convertible_v<std::remove_cvref_t<K>,
+                               typename select_tree_t<set_traits<Key, Compare, Allocator>, TreeSelector>::iterator> &&
+        !std::is_convertible_v<std::remove_cvref_t<K>, typename select_tree_t<set_traits<Key, Compare, Allocator>,
+                                                                              TreeSelector>::const_iterator>)
+set<Key, Compare, Allocator, TreeSelector>::size_type set<Key, Compare, Allocator, TreeSelector>::erase(K &&x) {
+    return _tree.erase(std::forward<K>(x));
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::iterator
+set<Key, Compare, Allocator, TreeSelector>::erase(const_iterator first, const_iterator last) {
+    return _tree.erase(first, last);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+void set<Key, Compare, Allocator, TreeSelector>::swap(set &x) noexcept(
+    std::allocator_traits<Allocator>::is_always_equal::value && std::is_nothrow_swappable_v<Compare>) {
+    _tree.swap(x._tree);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+void set<Key, Compare, Allocator, TreeSelector>::clear() noexcept {
+    _tree.clear();
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class C2>
+void set<Key, Compare, Allocator, TreeSelector>::merge(set<Key, C2, Allocator, TreeSelector> &source) {
+    if constexpr (std::is_same_v<Compare, std::remove_cvref_t<C2>>) { // Fast path
+        return _tree.merge(source._tree);
+    } // Slow path will be implemented later
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class C2>
+void set<Key, Compare, Allocator, TreeSelector>::merge(set<Key, C2, Allocator, TreeSelector> &&source) {
+    if constexpr (std::is_same_v<Compare, std::remove_cvref_t<C2>>) { // Fast path
+        return _tree.merge(std::move(source._tree));
+    } // Slow path will be implemented later
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class C2>
+void set<Key, Compare, Allocator, TreeSelector>::merge(::j::multiset<Key, C2, Allocator, TreeSelector> &source) {
+    if constexpr (std::is_same_v<Compare, std::remove_cvref_t<C2>>) { // Fast path
+        return _tree.merge(source._tree);
+    } // Slow path will be implemented later
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class C2>
+void set<Key, Compare, Allocator, TreeSelector>::merge(::j::multiset<Key, C2, Allocator, TreeSelector> &&source) {
+    if constexpr (std::is_same_v<Compare, std::remove_cvref_t<C2>>) { // Fast path
+        return _tree.merge(std::move(source._tree));
+    } // Slow path will be implemented later
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::key_compare set<Key, Compare, Allocator, TreeSelector>::key_comp() const {
+    return _tree.key_comp();
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::value_compare
+set<Key, Compare, Allocator, TreeSelector>::value_comp() const {
+    return _tree.value_comp();
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::iterator
+set<Key, Compare, Allocator, TreeSelector>::find(const key_type &x) {
+    return _tree.find(x);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::const_iterator
+set<Key, Compare, Allocator, TreeSelector>::find(const key_type &x) const {
+    return _tree.find(x);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class K>
+    requires IsTransparentlyComparable<K, typename set_traits<Key, Compare, Allocator>::key_type,
+                                       typename set_traits<Key, Compare, Allocator>::key_compare>
+set<Key, Compare, Allocator, TreeSelector>::iterator set<Key, Compare, Allocator, TreeSelector>::find(const K &x) {
+    return _tree.find(std::forward<const K &>(x));
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class K>
+    requires IsTransparentlyComparable<K, typename set_traits<Key, Compare, Allocator>::key_type,
+                                       typename set_traits<Key, Compare, Allocator>::key_compare>
+set<Key, Compare, Allocator, TreeSelector>::const_iterator
+set<Key, Compare, Allocator, TreeSelector>::find(const K &x) const {
+    return _tree.find(std::forward<const K &>(x));
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::size_type
+set<Key, Compare, Allocator, TreeSelector>::count(const key_type &x) const {
+    return _tree.count(x);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class K>
+    requires IsTransparentlyComparable<K, typename set_traits<Key, Compare, Allocator>::key_type,
+                                       typename set_traits<Key, Compare, Allocator>::key_compare>
+set<Key, Compare, Allocator, TreeSelector>::size_type
+set<Key, Compare, Allocator, TreeSelector>::count(const K &x) const {
+    return _tree.count(std::forward<const K &>(x));
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+bool set<Key, Compare, Allocator, TreeSelector>::contains(const key_type &x) const {
+    return _tree.contains(x);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class K>
+    requires IsTransparentlyComparable<K, typename set_traits<Key, Compare, Allocator>::key_type,
+                                       typename set_traits<Key, Compare, Allocator>::key_compare>
+bool set<Key, Compare, Allocator, TreeSelector>::contains(const K &x) const {
+    return _tree.contains(std::forward<const K &>(x));
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::iterator
+set<Key, Compare, Allocator, TreeSelector>::lower_bound(const key_type &x) {
+    return _tree.lower_bound(x);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::const_iterator
+set<Key, Compare, Allocator, TreeSelector>::lower_bound(const key_type &x) const {
+    return _tree.lower_bound(x);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class K>
+    requires IsTransparentlyComparable<K, typename set_traits<Key, Compare, Allocator>::key_type,
+                                       typename set_traits<Key, Compare, Allocator>::key_compare>
+set<Key, Compare, Allocator, TreeSelector>::iterator
+set<Key, Compare, Allocator, TreeSelector>::lower_bound(const K &x) {
+    return _tree.lower_bound(std::forward<const K &>(x));
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class K>
+    requires IsTransparentlyComparable<K, typename set_traits<Key, Compare, Allocator>::key_type,
+                                       typename set_traits<Key, Compare, Allocator>::key_compare>
+set<Key, Compare, Allocator, TreeSelector>::const_iterator
+set<Key, Compare, Allocator, TreeSelector>::lower_bound(const K &x) const {
+    return _tree.lower_bound(std::forward<const K &>(x));
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::iterator
+set<Key, Compare, Allocator, TreeSelector>::upper_bound(const key_type &x) {
+    return _tree.upper_bound(x);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+set<Key, Compare, Allocator, TreeSelector>::const_iterator
+set<Key, Compare, Allocator, TreeSelector>::upper_bound(const key_type &x) const {
+    return _tree.upper_bound(x);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class K>
+    requires IsTransparentlyComparable<K, typename set_traits<Key, Compare, Allocator>::key_type,
+                                       typename set_traits<Key, Compare, Allocator>::key_compare>
+set<Key, Compare, Allocator, TreeSelector>::iterator
+set<Key, Compare, Allocator, TreeSelector>::upper_bound(const K &x) {
+    return _tree.upper_bound(std::forward<const K &>(x));
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class K>
+    requires IsTransparentlyComparable<K, typename set_traits<Key, Compare, Allocator>::key_type,
+                                       typename set_traits<Key, Compare, Allocator>::key_compare>
+set<Key, Compare, Allocator, TreeSelector>::const_iterator
+set<Key, Compare, Allocator, TreeSelector>::upper_bound(const K &x) const {
+    return _tree.upper_bound(std::forward<const K &>(x));
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+std::pair<typename set<Key, Compare, Allocator, TreeSelector>::iterator,
+          typename set<Key, Compare, Allocator, TreeSelector>::iterator>
+set<Key, Compare, Allocator, TreeSelector>::equal_range(const key_type &x) {
+    return _tree.equal_range(x);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+std::pair<typename set<Key, Compare, Allocator, TreeSelector>::const_iterator,
+          typename set<Key, Compare, Allocator, TreeSelector>::const_iterator>
+set<Key, Compare, Allocator, TreeSelector>::equal_range(const key_type &x) const {
+    return _tree.equal_range(x);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class K>
+    requires IsTransparentlyComparable<K, typename set_traits<Key, Compare, Allocator>::key_type,
+                                       typename set_traits<Key, Compare, Allocator>::key_compare>
+std::pair<typename set<Key, Compare, Allocator, TreeSelector>::iterator,
+          typename set<Key, Compare, Allocator, TreeSelector>::iterator>
+set<Key, Compare, Allocator, TreeSelector>::equal_range(const K &x) {
+    return _tree.equal_range(std::forward<const K &>(x));
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class K>
+    requires IsTransparentlyComparable<K, typename set_traits<Key, Compare, Allocator>::key_type,
+                                       typename set_traits<Key, Compare, Allocator>::key_compare>
+std::pair<typename set<Key, Compare, Allocator, TreeSelector>::const_iterator,
+          typename set<Key, Compare, Allocator, TreeSelector>::const_iterator>
+set<Key, Compare, Allocator, TreeSelector>::equal_range(const K &x) const {
+    return _tree.equal_range(std::forward<const K &>(x));
+}
+} // namespace j
+
+namespace j {
+export template <class Key, class Compare = std::less<Key>, class Allocator = std::allocator<Key>, class TreeSelector>
+class multiset {
+  private:
+    using traits = multiset_traits<Key, Compare, Allocator>;
+    using tree_type = select_tree_t<traits, TreeSelector>;
+    tree_type _tree;
+
+  public:
+    using key_type = typename traits::key_type;
+    using key_compare = typename traits::key_compare;
+    using value_type = typename traits::value_type;
+    using value_compare = typename traits::value_compare;
+    using allocator_type = typename traits::allocator_type;
+    using pointer = typename std::allocator_traits<Allocator>::pointer;
+    using const_pointer = typename std::allocator_traits<Allocator>::const_pointer;
+    using reference = value_type &;
+    using const_reference = const value_type &;
+    using size_type = typename tree_type::size_type;
+    using difference_type = typename tree_type::difference_type;
+    using iterator = typename tree_type::iterator;
+    using const_iterator = typename tree_type::const_iterator;
+    using reverse_iterator = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+    using node_type = typename tree_type::node_type;
+
+    // construct/copy/destroy
+    multiset() : multiset(Compare()) {}
+    explicit multiset(const Compare &comp, const Allocator &alloc = Allocator());
+    template <class InputIter>
+        requires std::input_iterator<InputIter> &&
+                 std::constructible_from<value_type, typename std::iterator_traits<InputIter>::reference>
+    multiset(InputIter first, InputIter last, const Compare &comp = Compare(), const Allocator & = Allocator());
+    multiset(const multiset &x) = default; // Rule of zero
+    multiset(multiset &&x) = default;      // Rule of zero
+    explicit multiset(const Allocator &alloc);
+    multiset(const multiset &, const std::type_identity_t<Allocator> &alloc);
+    multiset(multiset &&, const std::type_identity_t<Allocator> &alloc);
+    multiset(std::initializer_list<value_type> il, const Compare &comp = Compare(),
+             const Allocator &alloc = Allocator());
+    template <class InputIter>
+    multiset(InputIter first, InputIter last, const Allocator &a) : multiset(first, last, Compare(), a) {}
+    multiset(std::initializer_list<value_type> il, const Allocator &a) : multiset(il, Compare(), a) {}
+    multiset &operator=(const multiset &x) = default; // Rule of zero
+    multiset &
+    operator=(multiset &&x) = default; // Rule of zero (noexcept depends on tree_type, compiler can optimize it)
+    multiset &operator=(std::initializer_list<value_type>);
+    ~multiset() = default; // Rule of zero
+    [[nodiscard]] allocator_type get_allocator() const noexcept;
+
+    // iterators
+    [[nodiscard]] iterator begin() noexcept;
+    [[nodiscard]] const_iterator begin() const noexcept;
+    [[nodiscard]] iterator end() noexcept;
+    [[nodiscard]] const_iterator end() const noexcept;
+
+    [[nodiscard]] reverse_iterator rbegin() noexcept;
+    [[nodiscard]] const_reverse_iterator rbegin() const noexcept;
+    [[nodiscard]] reverse_iterator rend() noexcept;
+    [[nodiscard]] const_reverse_iterator rend() const noexcept;
+
+    [[nodiscard]] const_iterator cbegin() const noexcept;
+    [[nodiscard]] const_iterator cend() const noexcept;
+    [[nodiscard]] const_reverse_iterator crbegin() const noexcept;
+    [[nodiscard]] const_reverse_iterator crend() const noexcept;
+
+    // capacity
+    [[nodiscard]] bool empty() const noexcept;
+    [[nodiscard]] size_type size() const noexcept;
+    [[nodiscard]] size_type max_size() const noexcept;
+
+    // modifiers
+    template <class... Args>
+        requires std::constructible_from<value_type, Args &&...>
+    iterator emplace(Args &&...args);
+    template <class... Args>
+        requires std::constructible_from<value_type, Args &&...>
+    iterator emplace_hint(const_iterator position, Args &&...args);
+    iterator insert(const value_type &x);
+    iterator insert(value_type &&x);
+    iterator insert(const_iterator position, const value_type &x);
+    iterator insert(const_iterator position, value_type &&x);
+    template <class InputIter> void insert(InputIter first, InputIter last);
+    void insert(std::initializer_list<value_type> il);
+
+    node_type extract(const_iterator position);
+    node_type extract(const key_type &x);
+    template <class K> node_type extract(K &&x);
+    iterator insert(node_type &&nh);
+    iterator insert(const_iterator hint, node_type &&nh);
+
+    iterator erase(iterator position)
+        requires(!std::same_as<iterator, const_iterator>);
+    iterator erase(const_iterator position);
+    size_type erase(const key_type &x);
+    template <class K> size_type erase(K &&x);
+    iterator erase(const_iterator first, const_iterator last);
+    void swap(multiset &) noexcept(std::allocator_traits<Allocator>::is_always_equal::value &&
+                                   std::is_nothrow_swappable_v<Compare>);
+    void clear() noexcept;
+
+    template <class C2> void merge(multiset<Key, C2, Allocator, TreeSelector> &source);
+    template <class C2> void merge(multiset<Key, C2, Allocator, TreeSelector> &&source);
+    template <class C2> void merge(set<Key, C2, Allocator, TreeSelector> &source);
+    template <class C2> void merge(set<Key, C2, Allocator, TreeSelector> &&source);
+
+    // observers
+    [[nodiscard]] key_compare key_comp() const;
+    [[nodiscard]] value_compare value_comp() const;
+
+    // set operations
+    [[nodiscard]] iterator find(const key_type &x);
+    [[nodiscard]] const_iterator find(const key_type &x) const;
+    template <class K> [[nodiscard]] iterator find(const K &x);
+    template <class K> [[nodiscard]] const_iterator find(const K &x) const;
+
+    [[nodiscard]] size_type count(const key_type &x) const;
+    template <class K> [[nodiscard]] size_type count(const K &x) const;
+
+    [[nodiscard]] bool contains(const key_type &x) const;
+    template <class K> [[nodiscard]] bool contains(const K &x) const;
+
+    [[nodiscard]] iterator lower_bound(const key_type &x);
+    [[nodiscard]] const_iterator lower_bound(const key_type &x) const;
+    template <class K> [[nodiscard]] iterator lower_bound(const K &x);
+    template <class K> [[nodiscard]] const_iterator lower_bound(const K &x) const;
+
+    [[nodiscard]] iterator upper_bound(const key_type &x);
+    [[nodiscard]] const_iterator upper_bound(const key_type &x) const;
+    template <class K> [[nodiscard]] iterator upper_bound(const K &x);
+    template <class K> [[nodiscard]] const_iterator upper_bound(const K &x) const;
+
+    [[nodiscard]] std::pair<iterator, iterator> equal_range(const key_type &x);
+    [[nodiscard]] std::pair<const_iterator, const_iterator> equal_range(const key_type &x) const;
+    template <class K> [[nodiscard]] std::pair<iterator, iterator> equal_range(const K &x);
+    template <class K> [[nodiscard]] std::pair<const_iterator, const_iterator> equal_range(const K &x) const;
+};
+
+template <class InputIter, class Compare = std::less<typename std::iterator_traits<InputIter>::value_type>,
+          class Allocator = std::allocator<typename std::iterator_traits<InputIter>::value_type>>
+multiset(InputIter, InputIter, Compare = Compare(), Allocator = Allocator())
+    -> multiset<typename std::iterator_traits<InputIter>::value_type, Compare, Allocator>;
+
+template <class Key, class Compare = std::less<Key>, class Allocator = std::allocator<Key>>
+multiset(std::initializer_list<Key>, Compare = Compare(), Allocator = Allocator()) -> multiset<Key, Compare, Allocator>;
+
+template <class InputIter, class Allocator>
+multiset(InputIter, InputIter, Allocator)
+    -> multiset<typename std::iterator_traits<InputIter>::value_type,
+                std::less<typename std::iterator_traits<InputIter>::value_type>, Allocator>;
+
+template <class Key, class Allocator>
+multiset(std::initializer_list<Key>, Allocator) -> multiset<Key, std::less<Key>, Allocator>;
+
+export template <class Key, class Compare, class Allocator, class TreeSelector>
+bool operator==(const multiset<Key, Compare, Allocator, TreeSelector> &lhs,
+                const multiset<Key, Compare, Allocator, TreeSelector> &rhs) {
+    return std::equal(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
+}
+
+export template <class Key, class Compare, class Allocator, class TreeSelector>
+auto operator<=>(const multiset<Key, Compare, Allocator, TreeSelector> &lhs,
+                 const multiset<Key, Compare, Allocator, TreeSelector> &rhs) -> std::strong_ordering {
+    return std::lexicographical_compare_three_way(lhs.begin(), lhs.end(), rhs.begin(), rhs.end(),
+                                                  std::compare_three_way{});
+}
+
+export template <class Key, class Compare, class Allocator, class TreeSelector>
+void swap(multiset<Key, Compare, Allocator, TreeSelector> &x,
+          multiset<Key, Compare, Allocator, TreeSelector> &y) noexcept(noexcept(x.swap(y))) {
+    x.swap(y);
+}
+
+export template <class Key, class Compare, class Allocator, class TreeSelector, class Pred>
+set<Key, Compare, Allocator, TreeSelector>::size_type erase_if(multiset<Key, Compare, Allocator, TreeSelector> &c,
+                                                               Pred pred) {
+    auto it = std::remove_if(c.begin(), c.end(), pred);
+    auto r = c.end() - it;
+    c.erase(it, c.end());
+    return r;
+}
+} // namespace j
+
+namespace j {
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::multiset(const Compare &comp, const Allocator &alloc)
+    : _tree(comp, alloc) {}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class InputIter>
+    requires std::input_iterator<InputIter> &&
+             std::constructible_from<typename multiset_traits<Key, Compare, Allocator>::value_type,
+                                     typename std::iterator_traits<InputIter>::reference>
+multiset<Key, Compare, Allocator, TreeSelector>::multiset(InputIter first, InputIter last, const Compare &comp,
+                                                          const Allocator &alloc)
+    : _tree(comp, alloc) {
+    _tree.insert(first, last);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::multiset(const Allocator &alloc) : _tree(Compare(), alloc) {}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::multiset(const multiset &x,
+                                                          const std::type_identity_t<Allocator> &alloc)
+    : _tree(x._tree, alloc) {}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::multiset(multiset &&x, const std::type_identity_t<Allocator> &alloc)
+    : _tree(std::move(x._tree), alloc) {}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::multiset(std::initializer_list<value_type> il, const Compare &comp,
+                                                          const Allocator &alloc)
+    : _tree(comp, alloc) {
+    _tree.insert(il.begin(), il.end());
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector> &
+multiset<Key, Compare, Allocator, TreeSelector>::operator=(std::initializer_list<value_type> il) {
+    _tree.clear();
+    _tree.insert(il.begin(), il.end());
+    return *this;
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::allocator_type
+multiset<Key, Compare, Allocator, TreeSelector>::get_allocator() const noexcept {
+    return _tree.get_allocator();
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::iterator
+multiset<Key, Compare, Allocator, TreeSelector>::begin() noexcept {
+    return _tree.begin();
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::const_iterator
+multiset<Key, Compare, Allocator, TreeSelector>::begin() const noexcept {
+    return _tree.cbegin();
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::iterator
+multiset<Key, Compare, Allocator, TreeSelector>::end() noexcept {
+    return _tree.end();
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::const_iterator
+multiset<Key, Compare, Allocator, TreeSelector>::end() const noexcept {
+    return _tree.cend();
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::reverse_iterator
+multiset<Key, Compare, Allocator, TreeSelector>::rbegin() noexcept {
+    return reverse_iterator(end());
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::const_reverse_iterator
+multiset<Key, Compare, Allocator, TreeSelector>::rbegin() const noexcept {
+    return const_reverse_iterator(end());
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::reverse_iterator
+multiset<Key, Compare, Allocator, TreeSelector>::rend() noexcept {
+    return reverse_iterator(begin());
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::const_reverse_iterator
+multiset<Key, Compare, Allocator, TreeSelector>::rend() const noexcept {
+    return const_reverse_iterator(begin());
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::const_iterator
+multiset<Key, Compare, Allocator, TreeSelector>::cbegin() const noexcept {
+    return _tree.cbegin();
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::const_iterator
+multiset<Key, Compare, Allocator, TreeSelector>::cend() const noexcept {
+    return _tree.cend();
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::const_reverse_iterator
+multiset<Key, Compare, Allocator, TreeSelector>::crbegin() const noexcept {
+    return const_reverse_iterator(cend());
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::const_reverse_iterator
+multiset<Key, Compare, Allocator, TreeSelector>::crend() const noexcept {
+    return const_reverse_iterator(cbegin());
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+bool multiset<Key, Compare, Allocator, TreeSelector>::empty() const noexcept {
+    return _tree.empty();
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::size_type
+multiset<Key, Compare, Allocator, TreeSelector>::size() const noexcept {
+    return _tree.size();
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::size_type
+multiset<Key, Compare, Allocator, TreeSelector>::max_size() const noexcept {
+    return _tree.max_size();
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class... Args>
+    requires std::constructible_from<typename multiset_traits<Key, Compare, Allocator>::value_type, Args &&...>
+multiset<Key, Compare, Allocator, TreeSelector>::iterator
+multiset<Key, Compare, Allocator, TreeSelector>::emplace(Args &&...args) {
+    return _tree.emplace(std::forward<Args>(args)...).first;
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class... Args>
+    requires std::constructible_from<typename multiset_traits<Key, Compare, Allocator>::value_type, Args &&...>
+multiset<Key, Compare, Allocator, TreeSelector>::iterator
+multiset<Key, Compare, Allocator, TreeSelector>::emplace_hint(const_iterator position, Args &&...args) {
+    return _tree.emplace_hint(position, std::forward<Args>(args)...);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::iterator
+multiset<Key, Compare, Allocator, TreeSelector>::insert(const value_type &x) {
+    return _tree.emplace(x).first;
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::iterator
+multiset<Key, Compare, Allocator, TreeSelector>::insert(value_type &&x) {
+    return _tree.emplace(std::move(x)).first;
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::iterator
+multiset<Key, Compare, Allocator, TreeSelector>::insert(const_iterator position, const value_type &x) {
+    return _tree.emplace_hint(position, x);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::iterator
+multiset<Key, Compare, Allocator, TreeSelector>::insert(const_iterator position, value_type &&x) {
+    return _tree.emplace_hint(position, std::move(x));
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class InputIter>
+void multiset<Key, Compare, Allocator, TreeSelector>::insert(InputIter first, InputIter last) {
+    return _tree.insert(first, last);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+void multiset<Key, Compare, Allocator, TreeSelector>::insert(std::initializer_list<value_type> il) {
+    return _tree.insert(il.begin(), il.end());
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::node_type
+multiset<Key, Compare, Allocator, TreeSelector>::extract(const_iterator position) {
+    return _tree.extract(position);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::node_type
+multiset<Key, Compare, Allocator, TreeSelector>::extract(const key_type &x) {
+    return _tree.extract(x);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class K>
+multiset<Key, Compare, Allocator, TreeSelector>::node_type
+multiset<Key, Compare, Allocator, TreeSelector>::extract(K &&x) {
+    return _tree.extract(std::forward<K>(x));
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::iterator
+multiset<Key, Compare, Allocator, TreeSelector>::insert(node_type &&nh) {
+    return _tree.insert(std::move(nh)).position;
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::iterator
+multiset<Key, Compare, Allocator, TreeSelector>::insert(const_iterator hint, node_type &&nh) {
+    return _tree.insert_hint(hint, std::move(nh));
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::iterator
+multiset<Key, Compare, Allocator, TreeSelector>::erase(iterator position)
+    requires(
+        !std::same_as<typename select_tree_t<multiset_traits<Key, Compare, Allocator>, TreeSelector>::iterator,
+                      typename select_tree_t<multiset_traits<Key, Compare, Allocator>, TreeSelector>::const_iterator>)
+{
+    return _tree.erase(position);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::iterator
+multiset<Key, Compare, Allocator, TreeSelector>::erase(const_iterator position) {
+    return _tree.erase(position);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::size_type
+multiset<Key, Compare, Allocator, TreeSelector>::erase(const key_type &x) {
+    return _tree.erase(x);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class K>
+multiset<Key, Compare, Allocator, TreeSelector>::size_type
+multiset<Key, Compare, Allocator, TreeSelector>::erase(K &&x) {
+    return _tree.erase(std::forward<K>(x));
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::iterator
+multiset<Key, Compare, Allocator, TreeSelector>::erase(const_iterator first, const_iterator last) {
+    return _tree.erase(first, last);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+void multiset<Key, Compare, Allocator, TreeSelector>::swap(multiset &x) noexcept(
+    std::allocator_traits<Allocator>::is_always_equal::value && std::is_nothrow_swappable_v<Compare>) {
+    _tree.swap(x._tree);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+void multiset<Key, Compare, Allocator, TreeSelector>::clear() noexcept {
+    _tree.clear();
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class C2>
+void multiset<Key, Compare, Allocator, TreeSelector>::merge(multiset<Key, C2, Allocator, TreeSelector> &source) {
+    if constexpr (std::is_same_v<Compare, std::remove_cvref_t<C2>>) { // Fast path
+        return _tree.merge(source._tree);
+    } // Slow path will be implemented later
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class C2>
+void multiset<Key, Compare, Allocator, TreeSelector>::merge(multiset<Key, C2, Allocator, TreeSelector> &&source) {
+    if constexpr (std::is_same_v<Compare, std::remove_cvref_t<C2>>) { // Fast path
+        return _tree.merge(std::move(source._tree));
+    } // Slow path will be implemented later
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class C2>
+void multiset<Key, Compare, Allocator, TreeSelector>::merge(set<Key, C2, Allocator, TreeSelector> &source) {
+    if constexpr (std::is_same_v<Compare, std::remove_cvref_t<C2>>) { // Fast path
+        return _tree.merge(source._tree);
+    } // Slow path will be implemented later
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class C2>
+void multiset<Key, Compare, Allocator, TreeSelector>::merge(set<Key, C2, Allocator, TreeSelector> &&source) {
+    if constexpr (std::is_same_v<Compare, std::remove_cvref_t<C2>>) { // Fast path
+        return _tree.merge(std::move(source._tree));
+    } // Slow path will be implemented later
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::key_compare
+multiset<Key, Compare, Allocator, TreeSelector>::key_comp() const {
+    return _tree.key_comp();
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::value_compare
+multiset<Key, Compare, Allocator, TreeSelector>::value_comp() const {
+    return _tree.value_comp();
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::iterator
+multiset<Key, Compare, Allocator, TreeSelector>::find(const key_type &x) {
+    return _tree.find(x);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::const_iterator
+multiset<Key, Compare, Allocator, TreeSelector>::find(const key_type &x) const {
+    return _tree.find(x);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class K>
+multiset<Key, Compare, Allocator, TreeSelector>::iterator
+multiset<Key, Compare, Allocator, TreeSelector>::find(const K &x) {
+    return _tree.find(std::forward<const K &>(x));
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class K>
+multiset<Key, Compare, Allocator, TreeSelector>::const_iterator
+multiset<Key, Compare, Allocator, TreeSelector>::find(const K &x) const {
+    return _tree.find(std::forward<const K &>(x));
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::size_type
+multiset<Key, Compare, Allocator, TreeSelector>::count(const key_type &x) const {
+    return _tree.count(x);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class K>
+multiset<Key, Compare, Allocator, TreeSelector>::size_type
+multiset<Key, Compare, Allocator, TreeSelector>::count(const K &x) const {
+    return _tree.count(std::forward<const K &>(x));
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+bool multiset<Key, Compare, Allocator, TreeSelector>::contains(const key_type &x) const {
+    return _tree.contains(x);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class K>
+bool multiset<Key, Compare, Allocator, TreeSelector>::contains(const K &x) const {
+    return _tree.contains(std::forward<const K &>(x));
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::iterator
+multiset<Key, Compare, Allocator, TreeSelector>::lower_bound(const key_type &x) {
+    return _tree.lower_bound(x);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::const_iterator
+multiset<Key, Compare, Allocator, TreeSelector>::lower_bound(const key_type &x) const {
+    return _tree.lower_bound(x);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class K>
+multiset<Key, Compare, Allocator, TreeSelector>::iterator
+multiset<Key, Compare, Allocator, TreeSelector>::lower_bound(const K &x) {
+    return _tree.lower_bound(std::forward<const K &>(x));
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class K>
+multiset<Key, Compare, Allocator, TreeSelector>::const_iterator
+multiset<Key, Compare, Allocator, TreeSelector>::lower_bound(const K &x) const {
+    return _tree.lower_bound(std::forward<const K &>(x));
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::iterator
+multiset<Key, Compare, Allocator, TreeSelector>::upper_bound(const key_type &x) {
+    return _tree.upper_bound(x);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+multiset<Key, Compare, Allocator, TreeSelector>::const_iterator
+multiset<Key, Compare, Allocator, TreeSelector>::upper_bound(const key_type &x) const {
+    return _tree.upper_bound(x);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class K>
+multiset<Key, Compare, Allocator, TreeSelector>::iterator
+multiset<Key, Compare, Allocator, TreeSelector>::upper_bound(const K &x) {
+    return _tree.upper_bound(std::forward<const K &>(x));
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class K>
+multiset<Key, Compare, Allocator, TreeSelector>::const_iterator
+multiset<Key, Compare, Allocator, TreeSelector>::upper_bound(const K &x) const {
+    return _tree.upper_bound(std::forward<const K &>(x));
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+std::pair<typename multiset<Key, Compare, Allocator, TreeSelector>::iterator,
+          typename multiset<Key, Compare, Allocator, TreeSelector>::iterator>
+multiset<Key, Compare, Allocator, TreeSelector>::equal_range(const key_type &x) {
+    return _tree.equal_range(x);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+std::pair<typename multiset<Key, Compare, Allocator, TreeSelector>::const_iterator,
+          typename multiset<Key, Compare, Allocator, TreeSelector>::const_iterator>
+multiset<Key, Compare, Allocator, TreeSelector>::equal_range(const key_type &x) const {
+    return _tree.equal_range(x);
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class K>
+std::pair<typename multiset<Key, Compare, Allocator, TreeSelector>::iterator,
+          typename multiset<Key, Compare, Allocator, TreeSelector>::iterator>
+multiset<Key, Compare, Allocator, TreeSelector>::equal_range(const K &x) {
+    return _tree.equal_range(std::forward<const K &>(x));
+}
+
+template <class Key, class Compare, class Allocator, class TreeSelector>
+template <class K>
+std::pair<typename multiset<Key, Compare, Allocator, TreeSelector>::const_iterator,
+          typename multiset<Key, Compare, Allocator, TreeSelector>::const_iterator>
+multiset<Key, Compare, Allocator, TreeSelector>::equal_range(const K &x) const {
+    return _tree.equal_range(std::forward<const K &>(x));
+}
+} // namespace j

--- a/modules/datastructures/Tree/tree_selector.cppm
+++ b/modules/datastructures/Tree/tree_selector.cppm
@@ -1,28 +1,42 @@
 /*
  * @ Created by jaehyung409 on 25. 9. 10..
- * @ Copyright (c) 2025 jaehyung409 
- * This software is licensed under the MIT License. 
+ * @ Copyright (c) 2025 jaehyung409
+ * This software is licensed under the MIT License.
  */
 
-#if defined(__clang__)
 export module j:tree_selector;
-#else
-module j:tree_selector;
-#endif
+
+import :skip_list;
+// import :red_black_tree;
+// import :avl_tree;
 
 namespace j {
-// tree policy tag
-// ex: struct use_XX{}; (draft)
+struct use_red_black_tree {};
+struct use_skip_list {};
+export struct use_avl_tree {};
 
-// concept
-// template <typename Policy>
-// concept TreePolicy = std::is_same_v<Policy use_XX> || ... ;
+template <class Traits, class Selector> struct select_tree {
+    using type = skip_list<Traits>;
+};
 
-// template <class Value, class Compare, class Alloc, class Policy>
-// struct tree_selector;
-//
-// template <class Value, class Compare, class Alloc>
-// struct tree_selector<Value, Compare, Alloc, use_XX> {
-//     using type = XX<Value, Compare, Alloc>;
-// };
-}
+template <class Traits> struct select_tree<Traits, use_skip_list> {
+    using type = skip_list<Traits>;
+};
+
+template <class Traits> struct select_tree<Traits, use_red_black_tree> {
+    // using type = red_black_tree<Traits>;
+};
+
+template <class Traits> struct select_tree<Traits, use_avl_tree> {
+    // using type = avl_tree<Traits>;
+};
+
+/* if custom
+ * template <class Traits>
+ * struct select_tree<Traits, use_custom_tree> {
+ *   using type = custom_tree<Traits>;
+ * };
+ */
+
+export template <class Traits, class Selector> using select_tree_t = typename select_tree<Traits, Selector>::type;
+} // namespace j

--- a/modules/datastructures/Tree/tree_selector.cppm
+++ b/modules/datastructures/Tree/tree_selector.cppm
@@ -1,0 +1,28 @@
+/*
+ * @ Created by jaehyung409 on 25. 9. 10..
+ * @ Copyright (c) 2025 jaehyung409 
+ * This software is licensed under the MIT License. 
+ */
+
+#if defined(__clang__)
+export module j:tree_selector;
+#else
+module j:tree_selector;
+#endif
+
+namespace j {
+// tree policy tag
+// ex: struct use_XX{}; (draft)
+
+// concept
+// template <typename Policy>
+// concept TreePolicy = std::is_same_v<Policy use_XX> || ... ;
+
+// template <class Value, class Compare, class Alloc, class Policy>
+// struct tree_selector;
+//
+// template <class Value, class Compare, class Alloc>
+// struct tree_selector<Value, Compare, Alloc, use_XX> {
+//     using type = XX<Value, Compare, Alloc>;
+// };
+}

--- a/modules/j.cppm
+++ b/modules/j.cppm
@@ -6,6 +6,8 @@
 
 export module j;
 
+export import :traits;
+
 export import :array;
 export import :list;
 export import :forward_list;

--- a/modules/j.cppm
+++ b/modules/j.cppm
@@ -16,4 +16,8 @@ export import :deque;
 export import :stack;
 export import :queue;
 
+export import :tree_selector;
+export import :map;
+export import :set;
+
 export import :algorithm;

--- a/modules/traits.cppm
+++ b/modules/traits.cppm
@@ -7,7 +7,11 @@
 module;
 #include <utility>
 
+#if defined(__clang__)
 export module j:traits;
+#else
+module j:traits;
+#endif
 
 namespace j {
 template <class T>

--- a/modules/traits.cppm
+++ b/modules/traits.cppm
@@ -17,6 +17,7 @@ namespace j {
 template <class T>
 struct key_traits {
     using key_type = T;
+    using mapped_type = void;
     using value_type = T;
 
     static const key_type& extract_key(const value_type& value) {

--- a/modules/traits.cppm
+++ b/modules/traits.cppm
@@ -1,7 +1,7 @@
 /*
  * @ Created by jaehyung409 on 25. 9. 10..
- * @ Copyright (c) 2025 jaehyung409 
- * This software is licensed under the MIT License. 
+ * @ Copyright (c) 2025 jaehyung409
+ * This software is licensed under the MIT License.
  */
 
 module;
@@ -14,43 +14,23 @@ module j:traits;
 #endif
 
 namespace j {
-template <class T>
-struct key_traits {
-    using key_type = T;
+template <class Key, class Compare, class Allocator> struct set_traits {
+    using key_type = Key;
     using mapped_type = void;
-    using value_type = T;
-
-    static const key_type& extract_key(const value_type& value) {
-        return value;
-    }
+    using value_type = key_type;
+    using key_compare = Compare;
+    using value_compare = key_compare;
+    using allocator_type = Allocator;
+    static constexpr bool _MULTI = false;
 };
 
-template <class K, class V>
-struct key_traits<std::pair<const K, V>> {
-    using key_type = K;
-    using mapped_type = V;
-    using value_type = std::pair<const K, V>;
-
-    static const key_type& extract_key(const value_type& value) {
-        return value.first;
-    }
+template <class Key, class Compare, class Allocator> struct multiset_traits {
+    using key_type = Key;
+    using mapped_type = void;
+    using value_type = key_type;
+    using key_compare = Compare;
+    using value_compare = key_compare;
+    using allocator_type = Allocator;
+    static constexpr bool _MULTI = true;
 };
-
-template <class Key, class Value, class Compare, class Traits>
-struct value_compare_traits {
-    using value_compare = std::conditional_t<
-        std::is_same_v<Value, Key>,
-        Compare,
-        struct value_compare_impl {
-        protected:
-            Compare comp;
-            explicit value_compare_impl(const Compare& c) : comp(c) {}
-        public:
-            bool operator()(const Value& lhs, const Value& rhs) const {
-                return comp(Traits::extract_key(lhs), Traits::extract_key(rhs));
-            }
-        }
-    >;
-};
-// need to add iterator related traits (const/non-const iterator)
-}
+} // namespace j

--- a/modules/traits.cppm
+++ b/modules/traits.cppm
@@ -1,0 +1,34 @@
+/*
+ * @ Created by jaehyung409 on 25. 9. 10..
+ * @ Copyright (c) 2025 jaehyung409 
+ * This software is licensed under the MIT License. 
+ */
+
+module;
+#include <utility>
+
+export module j:traits;
+
+namespace j {
+template <class T>
+struct key_traits {
+    using key_type = T;
+    using value_type = T;
+
+    static const key_type& extract_key(const value_type& value) {
+        return value;
+    }
+};
+
+template <class K, class V>
+struct key_traits<std::pair<const K, V>> {
+    using key_type = K;
+    using mapped_type = V;
+    using value_type = std::pair<const K, V>;
+
+    static const key_type& extract_key(const value_type& value) {
+        return value.first;
+    }
+};
+// need to add iterator related traits (const/non-const iterator)
+}

--- a/modules/traits.cppm
+++ b/modules/traits.cppm
@@ -35,5 +35,22 @@ struct key_traits<std::pair<const K, V>> {
         return value.first;
     }
 };
+
+template <class Key, class Value, class Compare, class Traits>
+struct value_compare_traits {
+    using value_compare = std::conditional_t<
+        std::is_same_v<Value, Key>,
+        Compare,
+        struct value_compare_impl {
+        protected:
+            Compare comp;
+            explicit value_compare_impl(const Compare& c) : comp(c) {}
+        public:
+            bool operator()(const Value& lhs, const Value& rhs) const {
+                return comp(Traits::extract_key(lhs), Traits::extract_key(rhs));
+            }
+        }
+    >;
+};
 // need to add iterator related traits (const/non-const iterator)
 }

--- a/test/datastructures/benchmark/bench_set.cpp
+++ b/test/datastructures/benchmark/bench_set.cpp
@@ -1,0 +1,909 @@
+/*
+ * @ Created by jaehyung409 on 25. 10. 4..
+ * @ Copyright (c) 2025 jaehyung409
+ * This software is licensed under the MIT License.
+ * Note: This benchmark code was generated with the assistance of an AI agent.
+ */
+
+#define CATCH_CONFIG_MAIN
+
+#include <catch2/catch_all.hpp>
+#include <numeric>
+#include <algorithm>
+#include <set>
+#include <random>
+import j;
+
+constexpr size_t N = 1000;
+std::random_device rd;
+std::mt19937 gen(42); // Fixed seed for reproducibility
+std::uniform_int_distribution<> dis(1, 10000);
+
+TEST_CASE("Set Benchmarks: Insert Operations") {
+    SECTION("Insert single element") {
+        BENCHMARK("j::set insert") {
+            j::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            return s.size();
+        };
+        BENCHMARK("std::set insert") {
+            std::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            return s.size();
+        };
+        BENCHMARK("j::multiset insert") {
+            j::multiset<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i % 500));
+            return s.size();
+        };
+        BENCHMARK("std::multiset insert") {
+            std::multiset<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i % 500));
+            return s.size();
+        };
+    }
+    SECTION("Insert with hint") {
+        BENCHMARK("j::set insert with hint") {
+            j::set<int> s;
+            auto hint = s.end();
+            for (size_t i = 0; i < N; ++i) hint = s.insert(hint, static_cast<int>(i));
+            return s.size();
+        };
+        BENCHMARK("std::set insert with hint") {
+            std::set<int> s;
+            auto hint = s.end();
+            for (size_t i = 0; i < N; ++i) hint = s.insert(hint, static_cast<int>(i));
+            return s.size();
+        };
+    }
+    SECTION("Insert random order") {
+        BENCHMARK("j::set insert random") {
+            j::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(dis(gen));
+            return s.size();
+        };
+        BENCHMARK("std::set insert random") {
+            std::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(dis(gen));
+            return s.size();
+        };
+    }
+}
+
+TEST_CASE("Set Benchmarks: Emplace Operations") {
+    SECTION("Emplace single element") {
+        BENCHMARK("j::set emplace") {
+            j::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.emplace(static_cast<int>(i));
+            return s.size();
+        };
+        BENCHMARK("std::set emplace") {
+            std::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.emplace(static_cast<int>(i));
+            return s.size();
+        };
+        BENCHMARK("j::multiset emplace") {
+            j::multiset<int> s;
+            for (size_t i = 0; i < N; ++i) s.emplace(static_cast<int>(i % 500));
+            return s.size();
+        };
+        BENCHMARK("std::multiset emplace") {
+            std::multiset<int> s;
+            for (size_t i = 0; i < N; ++i) s.emplace(static_cast<int>(i % 500));
+            return s.size();
+        };
+    }
+    SECTION("Emplace with hint") {
+        BENCHMARK("j::set emplace_hint") {
+            j::set<int> s;
+            auto hint = s.end();
+            for (size_t i = 0; i < N; ++i) hint = s.emplace_hint(hint, static_cast<int>(i));
+            return s.size();
+        };
+        BENCHMARK("std::set emplace_hint") {
+            std::set<int> s;
+            auto hint = s.end();
+            for (size_t i = 0; i < N; ++i) hint = s.emplace_hint(hint, static_cast<int>(i));
+            return s.size();
+        };
+    }
+}
+
+TEST_CASE("Set Benchmarks: Erase Operations") {
+    SECTION("Erase by key") {
+        BENCHMARK("j::set erase by key") {
+            j::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            for (size_t i = 0; i < N; ++i) s.erase(static_cast<int>(i));
+            return s.size();
+        };
+        BENCHMARK("std::set erase by key") {
+            std::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            for (size_t i = 0; i < N; ++i) s.erase(static_cast<int>(i));
+            return s.size();
+        };
+        BENCHMARK("j::multiset erase by key") {
+            j::multiset<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i % 500));
+            for (size_t i = 0; i < 500; ++i) s.erase(static_cast<int>(i));
+            return s.size();
+        };
+        BENCHMARK("std::multiset erase by key") {
+            std::multiset<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i % 500));
+            for (size_t i = 0; i < 500; ++i) s.erase(static_cast<int>(i));
+            return s.size();
+        };
+    }
+    SECTION("Erase by iterator") {
+        BENCHMARK("j::set erase by iterator") {
+            j::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            while (!s.empty()) s.erase(s.begin());
+            return s.size();
+        };
+        BENCHMARK("std::set erase by iterator") {
+            std::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            while (!s.empty()) s.erase(s.begin());
+            return s.size();
+        };
+    }
+    SECTION("Erase range") {
+        BENCHMARK("j::set erase range") {
+            j::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            auto it = s.begin();
+            std::advance(it, N / 2);
+            s.erase(s.begin(), it);
+            return s.size();
+        };
+        BENCHMARK("std::set erase range") {
+            std::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            auto it = s.begin();
+            std::advance(it, N / 2);
+            s.erase(s.begin(), it);
+            return s.size();
+        };
+    }
+}
+
+TEST_CASE("Set Benchmarks: Find Operations") {
+    SECTION("Find existing elements") {
+        BENCHMARK("j::set find") {
+            j::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            size_t found = 0;
+            for (size_t i = 0; i < N; ++i) {
+                if (s.find(static_cast<int>(i)) != s.end()) ++found;
+            }
+            return found;
+        };
+        BENCHMARK("std::set find") {
+            std::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            size_t found = 0;
+            for (size_t i = 0; i < N; ++i) {
+                if (s.find(static_cast<int>(i)) != s.end()) ++found;
+            }
+            return found;
+        };
+    }
+    SECTION("Find non-existing elements") {
+        BENCHMARK("j::set find missing") {
+            j::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            size_t found = 0;
+            for (size_t i = N; i < 2 * N; ++i) {
+                if (s.find(static_cast<int>(i)) != s.end()) ++found;
+            }
+            return found;
+        };
+        BENCHMARK("std::set find missing") {
+            std::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            size_t found = 0;
+            for (size_t i = N; i < 2 * N; ++i) {
+                if (s.find(static_cast<int>(i)) != s.end()) ++found;
+            }
+            return found;
+        };
+    }
+    SECTION("Random find pattern") {
+        BENCHMARK("j::set find random") {
+            j::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            size_t found = 0;
+            for (size_t i = 0; i < N; ++i) {
+                if (s.find(dis(gen) % (2 * N)) != s.end()) ++found;
+            }
+            return found;
+        };
+        BENCHMARK("std::set find random") {
+            std::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            size_t found = 0;
+            for (size_t i = 0; i < N; ++i) {
+                if (s.find(dis(gen) % (2 * N)) != s.end()) ++found;
+            }
+            return found;
+        };
+    }
+}
+
+TEST_CASE("Set Benchmarks: Contains Operations") {
+    SECTION("Contains existing elements") {
+        BENCHMARK("j::set contains") {
+            j::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            size_t found = 0;
+            for (size_t i = 0; i < N; ++i) {
+                if (s.contains(static_cast<int>(i))) ++found;
+            }
+            return found;
+        };
+        BENCHMARK("std::set contains") {
+            std::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            size_t found = 0;
+            for (size_t i = 0; i < N; ++i) {
+                if (s.contains(static_cast<int>(i))) ++found;
+            }
+            return found;
+        };
+    }
+}
+
+TEST_CASE("Set Benchmarks: Count Operations") {
+    SECTION("Count in set") {
+        BENCHMARK("j::set count") {
+            j::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            size_t total = 0;
+            for (size_t i = 0; i < N; ++i) total += s.count(static_cast<int>(i));
+            return total;
+        };
+        BENCHMARK("std::set count") {
+            std::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            size_t total = 0;
+            for (size_t i = 0; i < N; ++i) total += s.count(static_cast<int>(i));
+            return total;
+        };
+    }
+    SECTION("Count in multiset") {
+        BENCHMARK("j::multiset count") {
+            j::multiset<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i % 100));
+            size_t total = 0;
+            for (size_t i = 0; i < 100; ++i) total += s.count(static_cast<int>(i));
+            return total;
+        };
+        BENCHMARK("std::multiset count") {
+            std::multiset<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i % 100));
+            size_t total = 0;
+            for (size_t i = 0; i < 100; ++i) total += s.count(static_cast<int>(i));
+            return total;
+        };
+    }
+}
+
+TEST_CASE("Set Benchmarks: Bound Operations") {
+    SECTION("Lower bound") {
+        BENCHMARK("j::set lower_bound") {
+            j::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i * 2));
+            size_t count = 0;
+            for (size_t i = 0; i < N; ++i) {
+                if (s.lower_bound(static_cast<int>(i)) != s.end()) ++count;
+            }
+            return count;
+        };
+        BENCHMARK("std::set lower_bound") {
+            std::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i * 2));
+            size_t count = 0;
+            for (size_t i = 0; i < N; ++i) {
+                if (s.lower_bound(static_cast<int>(i)) != s.end()) ++count;
+            }
+            return count;
+        };
+    }
+    SECTION("Upper bound") {
+        BENCHMARK("j::set upper_bound") {
+            j::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i * 2));
+            size_t count = 0;
+            for (size_t i = 0; i < N; ++i) {
+                if (s.upper_bound(static_cast<int>(i)) != s.end()) ++count;
+            }
+            return count;
+        };
+        BENCHMARK("std::set upper_bound") {
+            std::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i * 2));
+            size_t count = 0;
+            for (size_t i = 0; i < N; ++i) {
+                if (s.upper_bound(static_cast<int>(i)) != s.end()) ++count;
+            }
+            return count;
+        };
+    }
+    SECTION("Equal range") {
+        BENCHMARK("j::set equal_range") {
+            j::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            size_t count = 0;
+            for (size_t i = 0; i < N; ++i) {
+                auto [first, last] = s.equal_range(static_cast<int>(i));
+                count += std::distance(first, last);
+            }
+            return count;
+        };
+        BENCHMARK("std::set equal_range") {
+            std::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            size_t count = 0;
+            for (size_t i = 0; i < N; ++i) {
+                auto [first, last] = s.equal_range(static_cast<int>(i));
+                count += std::distance(first, last);
+            }
+            return count;
+        };
+    }
+    SECTION("Equal range in multiset") {
+        BENCHMARK("j::multiset equal_range") {
+            j::multiset<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i % 100));
+            size_t count = 0;
+            for (size_t i = 0; i < 100; ++i) {
+                auto [first, last] = s.equal_range(static_cast<int>(i));
+                count += std::distance(first, last);
+            }
+            return count;
+        };
+        BENCHMARK("std::multiset equal_range") {
+            std::multiset<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i % 100));
+            size_t count = 0;
+            for (size_t i = 0; i < 100; ++i) {
+                auto [first, last] = s.equal_range(static_cast<int>(i));
+                count += std::distance(first, last);
+            }
+            return count;
+        };
+    }
+}
+
+TEST_CASE("Set Benchmarks: Iteration Operations") {
+    SECTION("Forward iteration") {
+        BENCHMARK("j::set forward iter") {
+            j::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            size_t sum = 0;
+            for (auto it = s.begin(); it != s.end(); ++it) sum += *it;
+            return sum;
+        };
+        BENCHMARK("std::set forward iter") {
+            std::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            size_t sum = 0;
+            for (auto it = s.begin(); it != s.end(); ++it) sum += *it;
+            return sum;
+        };
+    }
+    SECTION("Reverse iteration") {
+        BENCHMARK("j::set reverse iter") {
+            j::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            size_t sum = 0;
+            for (auto it = s.rbegin(); it != s.rend(); ++it) sum += *it;
+            return sum;
+        };
+        BENCHMARK("std::set reverse iter") {
+            std::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            size_t sum = 0;
+            for (auto it = s.rbegin(); it != s.rend(); ++it) sum += *it;
+            return sum;
+        };
+    }
+    SECTION("Range-based for loop") {
+        BENCHMARK("j::set range-for") {
+            j::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            size_t sum = 0;
+            for (int x : s) sum += x;
+            return sum;
+        };
+        BENCHMARK("std::set range-for") {
+            std::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            size_t sum = 0;
+            for (int x : s) sum += x;
+            return sum;
+        };
+    }
+}
+
+TEST_CASE("Set Benchmarks: Memory/State Operations") {
+    SECTION("Clear") {
+        BENCHMARK("j::set clear") {
+            j::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            s.clear();
+            return s.size();
+        };
+        BENCHMARK("std::set clear") {
+            std::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            s.clear();
+            return s.size();
+        };
+    }
+    SECTION("Swap") {
+        BENCHMARK("j::set swap") {
+            j::set<int> s1, s2;
+            for (size_t i = 0; i < N; ++i) s1.insert(static_cast<int>(i));
+            for (size_t i = N; i < 2 * N; ++i) s2.insert(static_cast<int>(i));
+            s1.swap(s2);
+            return s1.size() + s2.size();
+        };
+        BENCHMARK("std::set swap") {
+            std::set<int> s1, s2;
+            for (size_t i = 0; i < N; ++i) s1.insert(static_cast<int>(i));
+            for (size_t i = N; i < 2 * N; ++i) s2.insert(static_cast<int>(i));
+            s1.swap(s2);
+            return s1.size() + s2.size();
+        };
+    }
+}
+
+TEST_CASE("Set Benchmarks: Copy/Move Operations") {
+    SECTION("Copy construction") {
+        BENCHMARK("j::set copy construct") {
+            j::set<int> original;
+            for (size_t i = 0; i < N; ++i) original.insert(static_cast<int>(i));
+            j::set<int> copy = original;
+            return copy.size();
+        };
+        BENCHMARK("std::set copy construct") {
+            std::set<int> original;
+            for (size_t i = 0; i < N; ++i) original.insert(static_cast<int>(i));
+            std::set<int> copy = original;
+            return copy.size();
+        };
+    }
+    SECTION("Move construction") {
+        BENCHMARK("j::set move construct") {
+            j::set<int> original;
+            for (size_t i = 0; i < N; ++i) original.insert(static_cast<int>(i));
+            j::set<int> moved = std::move(original);
+            return moved.size();
+        };
+        BENCHMARK("std::set move construct") {
+            std::set<int> original;
+            for (size_t i = 0; i < N; ++i) original.insert(static_cast<int>(i));
+            std::set<int> moved = std::move(original);
+            return moved.size();
+        };
+    }
+    SECTION("Copy assignment") {
+        BENCHMARK("j::set copy assign") {
+            j::set<int> original, target;
+            for (size_t i = 0; i < N; ++i) original.insert(static_cast<int>(i));
+            target = original;
+            return target.size();
+        };
+        BENCHMARK("std::set copy assign") {
+            std::set<int> original, target;
+            for (size_t i = 0; i < N; ++i) original.insert(static_cast<int>(i));
+            target = original;
+            return target.size();
+        };
+    }
+    SECTION("Move assignment") {
+        BENCHMARK("j::set move assign") {
+            j::set<int> original, target;
+            for (size_t i = 0; i < N; ++i) original.insert(static_cast<int>(i));
+            target = std::move(original);
+            return target.size();
+        };
+        BENCHMARK("std::set move assign") {
+            std::set<int> original, target;
+            for (size_t i = 0; i < N; ++i) original.insert(static_cast<int>(i));
+            target = std::move(original);
+            return target.size();
+        };
+    }
+}
+
+TEST_CASE("Set Benchmarks: Construction Variants") {
+    std::vector<int> v(N);
+    std::iota(v.begin(), v.end(), 0);
+    SECTION("Range construction") {
+        BENCHMARK("j::set range construct") {
+            j::set<int> s(v.begin(), v.end());
+            return s.size();
+        };
+        BENCHMARK("std::set range construct") {
+            std::set<int> s(v.begin(), v.end());
+            return s.size();
+        };
+    }
+    SECTION("Initializer list construction") {
+        BENCHMARK("j::set initializer_list construct") {
+            j::set<int> s = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+            return s.size();
+        };
+        BENCHMARK("std::set initializer_list construct") {
+            std::set<int> s = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+            return s.size();
+        };
+    }
+}
+
+TEST_CASE("Set Benchmarks: Insert Range Operations") {
+    std::vector<int> v(100);
+    std::iota(v.begin(), v.end(), 0);
+    SECTION("Insert iterator range") {
+        BENCHMARK("j::set insert range") {
+            j::set<int> s;
+            s.insert(v.begin(), v.end());
+            return s.size();
+        };
+        BENCHMARK("std::set insert range") {
+            std::set<int> s;
+            s.insert(v.begin(), v.end());
+            return s.size();
+        };
+    }
+    SECTION("Insert initializer_list") {
+        BENCHMARK("j::set insert ilist") {
+            j::set<int> s;
+            s.insert({1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+            return s.size();
+        };
+        BENCHMARK("std::set insert ilist") {
+            std::set<int> s;
+            s.insert({1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+            return s.size();
+        };
+    }
+}
+
+TEST_CASE("Set Benchmarks: Extract Operations") {
+    SECTION("Extract by iterator") {
+        BENCHMARK("j::set extract iterator") {
+            j::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            size_t count = 0;
+            for (size_t i = 0; i < N / 10; ++i) {
+                auto nh = s.extract(s.begin());
+                if (!nh.empty()) ++count;
+            }
+            return count;
+        };
+        BENCHMARK("std::set extract iterator") {
+            std::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            size_t count = 0;
+            for (size_t i = 0; i < N / 10; ++i) {
+                auto nh = s.extract(s.begin());
+                if (!nh.empty()) ++count;
+            }
+            return count;
+        };
+    }
+    SECTION("Extract by key") {
+        BENCHMARK("j::set extract key") {
+            j::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            size_t count = 0;
+            for (size_t i = 0; i < N / 10; ++i) {
+                auto nh = s.extract(static_cast<int>(i));
+                if (!nh.empty()) ++count;
+            }
+            return count;
+        };
+        BENCHMARK("std::set extract key") {
+            std::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            size_t count = 0;
+            for (size_t i = 0; i < N / 10; ++i) {
+                auto nh = s.extract(static_cast<int>(i));
+                if (!nh.empty()) ++count;
+            }
+            return count;
+        };
+    }
+}
+
+TEST_CASE("Set Benchmarks: Node Handle Insert") {
+    SECTION("Insert node_type") {
+        BENCHMARK("j::set insert node_type") {
+            j::set<int> s1, s2;
+            for (size_t i = 0; i < N; ++i) s1.insert(static_cast<int>(i));
+            size_t count = 0;
+            for (size_t i = 0; i < N / 10; ++i) {
+                auto nh = s1.extract(s1.begin());
+                if (!nh.empty()) {
+                    s2.insert(std::move(nh));
+                    ++count;
+                }
+            }
+            return count;
+        };
+        BENCHMARK("std::set insert node_type") {
+            std::set<int> s1, s2;
+            for (size_t i = 0; i < N; ++i) s1.insert(static_cast<int>(i));
+            size_t count = 0;
+            for (size_t i = 0; i < N / 10; ++i) {
+                auto nh = s1.extract(s1.begin());
+                if (!nh.empty()) {
+                    s2.insert(std::move(nh));
+                    ++count;
+                }
+            }
+            return count;
+        };
+    }
+}
+
+TEST_CASE("Set Benchmarks: Merge Operations") {
+    SECTION("Merge set to set") {
+        BENCHMARK("j::set merge") {
+            j::set<int> s1, s2;
+            for (size_t i = 0; i < N / 2; ++i) s1.insert(static_cast<int>(i));
+            for (size_t i = N / 4; i < 3 * N / 4; ++i) s2.insert(static_cast<int>(i));
+            s1.merge(s2);
+            return s1.size() + s2.size();
+        };
+        BENCHMARK("std::set merge") {
+            std::set<int> s1, s2;
+            for (size_t i = 0; i < N / 2; ++i) s1.insert(static_cast<int>(i));
+            for (size_t i = N / 4; i < 3 * N / 4; ++i) s2.insert(static_cast<int>(i));
+            s1.merge(s2);
+            return s1.size() + s2.size();
+        };
+    }
+    // SECTION("Merge multiset to set") {
+    //     BENCHMARK("j::set merge from multiset") {
+    //         j::set<int> s1;
+    //         j::multiset<int> s2;
+    //         for (size_t i = 0; i < N / 2; ++i) s1.insert(static_cast<int>(i));
+    //         for (size_t i = 0; i < N; ++i) s2.insert(static_cast<int>(i % (N / 2)));
+    //         s1.merge(s2);
+    //         return s1.size() + s2.size();
+    //     };
+    //     BENCHMARK("std::set merge from multiset") {
+    //         std::set<int> s1;
+    //         std::multiset<int> s2;
+    //         for (size_t i = 0; i < N / 2; ++i) s1.insert(static_cast<int>(i));
+    //         for (size_t i = 0; i < N; ++i) s2.insert(static_cast<int>(i % (N / 2)));
+    //         s1.merge(s2);
+    //         return s1.size() + s2.size();
+    //     };
+    // }
+    SECTION("Merge multiset to multiset") {
+        BENCHMARK("j::multiset merge") {
+            j::multiset<int> s1, s2;
+            for (size_t i = 0; i < N / 2; ++i) s1.insert(static_cast<int>(i % 100));
+            for (size_t i = 0; i < N / 2; ++i) s2.insert(static_cast<int>(i % 100));
+            s1.merge(s2);
+            return s1.size() + s2.size();
+        };
+        BENCHMARK("std::multiset merge") {
+            std::multiset<int> s1, s2;
+            for (size_t i = 0; i < N / 2; ++i) s1.insert(static_cast<int>(i % 100));
+            for (size_t i = 0; i < N / 2; ++i) s2.insert(static_cast<int>(i % 100));
+            s1.merge(s2);
+            return s1.size() + s2.size();
+        };
+    }
+}
+
+TEST_CASE("Set Benchmarks: Algorithm Integration") {
+    SECTION("std::find") {
+        BENCHMARK("j::set std::find") {
+            j::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            size_t found_count = 0;
+            for (size_t i = 0; i < 100; ++i) {
+                auto target = dis(gen) % N;
+                auto it = std::find(s.begin(), s.end(), target);
+                if (it != s.end()) ++found_count;
+            }
+            return found_count;
+        };
+        BENCHMARK("std::set std::find") {
+            std::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            size_t found_count = 0;
+            for (size_t i = 0; i < 100; ++i) {
+                auto target = dis(gen) % N;
+                auto it = std::find(s.begin(), s.end(), target);
+                if (it != s.end()) ++found_count;
+            }
+            return found_count;
+        };
+    }
+    SECTION("std::accumulate") {
+        BENCHMARK("j::set std::accumulate") {
+            j::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            return std::accumulate(s.begin(), s.end(), 0);
+        };
+        BENCHMARK("std::set std::accumulate") {
+            std::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            return std::accumulate(s.begin(), s.end(), 0);
+        };
+    }
+    SECTION("std::count_if") {
+        BENCHMARK("j::set std::count_if") {
+            j::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            return std::count_if(s.begin(), s.end(), [](int x) { return x % 2 == 0; });
+        };
+        BENCHMARK("std::set std::count_if") {
+            std::set<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i));
+            return std::count_if(s.begin(), s.end(), [](int x) { return x % 2 == 0; });
+        };
+    }
+}
+
+TEST_CASE("Set Benchmarks: Mixed Operations Pattern") {
+    SECTION("Interleaved insert/erase") {
+        BENCHMARK("j::set insert/erase mix") {
+            j::set<int> s;
+            for (size_t i = 0; i < N; ++i) {
+                s.insert(static_cast<int>(i));
+                if (i % 3 == 0 && !s.empty()) s.erase(s.begin());
+            }
+            return s.size();
+        };
+        BENCHMARK("std::set insert/erase mix") {
+            std::set<int> s;
+            for (size_t i = 0; i < N; ++i) {
+                s.insert(static_cast<int>(i));
+                if (i % 3 == 0 && !s.empty()) s.erase(s.begin());
+            }
+            return s.size();
+        };
+    }
+    SECTION("Interleaved insert/find") {
+        BENCHMARK("j::set insert/find mix") {
+            j::set<int> s;
+            size_t found = 0;
+            for (size_t i = 0; i < N; ++i) {
+                s.insert(static_cast<int>(i));
+                if (i > 0 && s.find(static_cast<int>(i / 2)) != s.end()) ++found;
+            }
+            return found;
+        };
+        BENCHMARK("std::set insert/find mix") {
+            std::set<int> s;
+            size_t found = 0;
+            for (size_t i = 0; i < N; ++i) {
+                s.insert(static_cast<int>(i));
+                if (i > 0 && s.find(static_cast<int>(i / 2)) != s.end()) ++found;
+            }
+            return found;
+        };
+    }
+}
+
+TEST_CASE("Set Benchmarks: Large Scale Operations") {
+    constexpr size_t LARGE_N = 10000;
+    SECTION("Large insert sequential") {
+        BENCHMARK("j::set large insert seq") {
+            j::set<int> s;
+            for (size_t i = 0; i < LARGE_N; ++i) s.insert(static_cast<int>(i));
+            return s.size();
+        };
+        BENCHMARK("std::set large insert seq") {
+            std::set<int> s;
+            for (size_t i = 0; i < LARGE_N; ++i) s.insert(static_cast<int>(i));
+            return s.size();
+        };
+    }
+    SECTION("Large insert random") {
+        BENCHMARK("j::set large insert random") {
+            j::set<int> s;
+            for (size_t i = 0; i < LARGE_N; ++i) s.insert(dis(gen));
+            return s.size();
+        };
+        BENCHMARK("std::set large insert random") {
+            std::set<int> s;
+            for (size_t i = 0; i < LARGE_N; ++i) s.insert(dis(gen));
+            return s.size();
+        };
+    }
+    SECTION("Large find operations") {
+        BENCHMARK("j::set large find") {
+            j::set<int> s;
+            for (size_t i = 0; i < LARGE_N; ++i) s.insert(static_cast<int>(i));
+            size_t found = 0;
+            for (size_t i = 0; i < LARGE_N; ++i) {
+                if (s.find(static_cast<int>(i)) != s.end()) ++found;
+            }
+            return found;
+        };
+        BENCHMARK("std::set large find") {
+            std::set<int> s;
+            for (size_t i = 0; i < LARGE_N; ++i) s.insert(static_cast<int>(i));
+            size_t found = 0;
+            for (size_t i = 0; i < LARGE_N; ++i) {
+                if (s.find(static_cast<int>(i)) != s.end()) ++found;
+            }
+            return found;
+        };
+    }
+    SECTION("Large iteration") {
+        BENCHMARK("j::set large iterate") {
+            j::set<int> s;
+            for (size_t i = 0; i < LARGE_N; ++i) s.insert(static_cast<int>(i));
+            size_t sum = 0;
+            for (int x : s) sum += x;
+            return sum;
+        };
+        BENCHMARK("std::set large iterate") {
+            std::set<int> s;
+            for (size_t i = 0; i < LARGE_N; ++i) s.insert(static_cast<int>(i));
+            size_t sum = 0;
+            for (int x : s) sum += x;
+            return sum;
+        };
+    }
+}
+
+TEST_CASE("Set Benchmarks: Multiset Specific Operations") {
+    SECTION("Multiset duplicate inserts") {
+        BENCHMARK("j::multiset many duplicates") {
+            j::multiset<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i % 10));
+            return s.size();
+        };
+        BENCHMARK("std::multiset many duplicates") {
+            std::multiset<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i % 10));
+            return s.size();
+        };
+    }
+    SECTION("Multiset count duplicates") {
+        BENCHMARK("j::multiset count duplicates") {
+            j::multiset<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i % 50));
+            size_t total = 0;
+            for (size_t i = 0; i < 50; ++i) total += s.count(static_cast<int>(i));
+            return total;
+        };
+        BENCHMARK("std::multiset count duplicates") {
+            std::multiset<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i % 50));
+            size_t total = 0;
+            for (size_t i = 0; i < 50; ++i) total += s.count(static_cast<int>(i));
+            return total;
+        };
+    }
+    SECTION("Multiset erase all duplicates") {
+        BENCHMARK("j::multiset erase all dupes") {
+            j::multiset<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i % 50));
+            for (size_t i = 0; i < 50; ++i) s.erase(static_cast<int>(i));
+            return s.size();
+        };
+        BENCHMARK("std::multiset erase all dupes") {
+            std::multiset<int> s;
+            for (size_t i = 0; i < N; ++i) s.insert(static_cast<int>(i % 50));
+            for (size_t i = 0; i < 50; ++i) s.erase(static_cast<int>(i));
+            return s.size();
+        };
+    }
+}
+

--- a/test/datastructures/test_set.cpp
+++ b/test/datastructures/test_set.cpp
@@ -1,0 +1,594 @@
+/*
+ * @ Created by jaehyung409 on 25. 10. 2.
+ * @ Copyright (c) 2025 jaehyung409 All rights reserved.
+ * This software is licensed under the MIT License.
+ * Note: This test code was generated with the assistance of an AI agent.
+ */
+
+#define CATCH_CONFIG_MAIN
+
+#include <catch2/catch_all.hpp>
+#include <vector>
+#include <numeric>
+#include <algorithm>
+#include <string>
+#include <functional>
+import j;
+
+const int N = 10000;
+const int DUPLICATES = 10;
+
+TEST_CASE("Set Basic") {
+    j::set<int> s;
+    j::set<int> s_init = {5, 2, 8, 1, 9, 3};
+    j::set<std::string> s_str = {"apple", "banana", "cherry"};
+
+    SECTION("Construction and Initialization") {
+        REQUIRE(s.empty());
+        REQUIRE(s.size() == 0);
+
+        REQUIRE(!s_init.empty());
+        REQUIRE(s_init.size() == 6);
+
+        // Test deduction guide
+        j::set s_deduction = {10, 20, 30};
+        REQUIRE(s_deduction.size() == 3);
+        REQUIRE(s_deduction.contains(20));
+    }
+
+    SECTION("Iterator construction") {
+        std::vector<int> vec = {4, 1, 7, 2, 9};
+        j::set<int> s_iter(vec.begin(), vec.end());
+        REQUIRE(s_iter.size() == 5);
+        REQUIRE(s_iter.contains(4));
+        REQUIRE(s_iter.contains(9));
+    }
+
+    SECTION("Copy and Move construction") {
+        j::set<int> s_copy(s_init);
+        REQUIRE(s_copy.size() == s_init.size());
+        REQUIRE(s_copy == s_init);
+
+        j::set<int> s_move(std::move(s_copy));
+        REQUIRE(s_move.size() == 6);
+        REQUIRE((s_copy.empty() || s_copy.size() == 6)); // Implementation dependent
+    }
+
+    SECTION("Insert operations") {
+        auto [it1, inserted1] = s.insert(10);
+        REQUIRE(inserted1);
+        REQUIRE(*it1 == 10);
+        REQUIRE(s.size() == 1);
+
+        auto [it2, inserted2] = s.insert(10); // Duplicate
+        REQUIRE(!inserted2);
+        REQUIRE(*it2 == 10);
+        REQUIRE(s.size() == 1);
+
+        // Insert with hint
+        auto it3 = s.insert(it1, 15);
+        REQUIRE(*it3 == 15);
+        REQUIRE(s.size() == 2);
+    }
+
+    SECTION("Emplace operations") {
+        auto [it1, inserted1] = s.emplace(42);
+        REQUIRE(inserted1);
+        REQUIRE(*it1 == 42);
+
+        auto [it2, inserted2] = s.emplace(42); // Duplicate
+        REQUIRE(!inserted2);
+
+        // Emplace with hint
+        auto it3 = s.emplace_hint(it1, 50);
+        REQUIRE(*it3 == 50);
+    }
+
+    SECTION("Find and Contains") {
+        REQUIRE(s_init.contains(5));
+        REQUIRE(!s_init.contains(100));
+
+        auto it = s_init.find(8);
+        REQUIRE(it != s_init.end());
+        REQUIRE(*it == 8);
+
+        auto it_not_found = s_init.find(100);
+        REQUIRE(it_not_found == s_init.end());
+    }
+
+    SECTION("Count operations") {
+        REQUIRE(s_init.count(5) == 1);
+        REQUIRE(s_init.count(100) == 0);
+    }
+
+    SECTION("Bound operations") {
+        // lower_bound
+        auto lb = s_init.lower_bound(5);
+        REQUIRE(lb != s_init.end());
+        REQUIRE(*lb == 5);
+
+        // upper_bound
+        auto ub = s_init.upper_bound(5);
+        REQUIRE(ub != s_init.end());
+        REQUIRE(*ub > 5);
+
+        // equal_range
+        auto [first, last] = s_init.equal_range(5);
+        REQUIRE(first != s_init.end());
+        REQUIRE(*first == 5);
+        REQUIRE(std::distance(first, last) == 1);
+    }
+
+    SECTION("Erase operations") {
+        j::set<int> s_erase = {1, 2, 3, 4, 5};
+
+        // Erase by key
+        auto erased_count = s_erase.erase(3);
+        REQUIRE(erased_count == 1);
+        REQUIRE(!s_erase.contains(3));
+        REQUIRE(s_erase.size() == 4);
+
+        // Erase by iterator
+        auto it = s_erase.find(2);
+        REQUIRE(it != s_erase.end());
+        auto next_it = s_erase.erase(it);
+        REQUIRE(!s_erase.contains(2));
+        REQUIRE(*next_it > 2);
+
+        // Erase range
+        auto first = s_erase.begin();
+        auto last = std::next(first, 2);
+        s_erase.erase(first, last);
+        REQUIRE(s_erase.size() == 1);
+    }
+
+    SECTION("Iterators") {
+        std::vector<int> result;
+        for (auto it = s_init.begin(); it != s_init.end(); ++it) {
+            result.push_back(*it);
+        }
+        REQUIRE(std::is_sorted(result.begin(), result.end()));
+
+        // Reverse iterators
+        std::vector<int> reverse_result;
+        for (auto it = s_init.rbegin(); it != s_init.rend(); ++it) {
+            reverse_result.push_back(*it);
+        }
+        REQUIRE(std::is_sorted(reverse_result.rbegin(), reverse_result.rend()));
+    }
+
+    SECTION("Clear and Swap") {
+        j::set<int> s1 = {1, 2, 3};
+        j::set<int> s2 = {4, 5, 6};
+
+        s1.clear();
+        REQUIRE(s1.empty());
+
+        s1 = {7, 8, 9};
+        s1.swap(s2);
+        REQUIRE(s1.contains(4));
+        REQUIRE(s2.contains(7));
+    }
+
+    SECTION("Comparison operators") {
+        j::set<int> s1 = {1, 2, 3};
+        j::set<int> s2 = {1, 2, 3};
+        j::set<int> s3 = {1, 2, 4};
+
+        REQUIRE(s1 == s2);
+        REQUIRE(s1 != s3);
+        REQUIRE((s1 <=> s3) == std::strong_ordering::less);
+    }
+
+    SECTION("Key and Value comparison") {
+        auto key_comp = s_init.key_comp();
+        auto value_comp = s_init.value_comp();
+
+        REQUIRE(key_comp(1, 2));
+        REQUIRE(!key_comp(2, 1));
+        REQUIRE(value_comp(1, 2));
+        REQUIRE(!value_comp(2, 1));
+    }
+}
+
+TEST_CASE("MultiSet Basic") {
+    j::multiset<int> ms;
+    j::multiset<int> ms_init = {5, 2, 8, 1, 9, 3, 5, 2}; // With duplicates
+    j::multiset<std::string> ms_str = {"apple", "banana", "cherry", "apple"};
+
+    SECTION("Construction and Initialization") {
+        REQUIRE(ms.empty());
+        REQUIRE(ms.size() == 0);
+
+        REQUIRE(!ms_init.empty());
+        REQUIRE(ms_init.size() == 8); // Includes duplicates
+
+        // Test deduction guide
+        j::multiset ms_deduction = {10, 20, 30, 20};
+        REQUIRE(ms_deduction.size() == 4);
+        REQUIRE(ms_deduction.count(20) == 2);
+    }
+
+    SECTION("Insert operations with duplicates") {
+        auto it1 = ms.insert(10);
+        REQUIRE(*it1 == 10);
+        REQUIRE(ms.size() == 1);
+
+        auto it2 = ms.insert(10); // Duplicate allowed
+        REQUIRE(*it2 == 10);
+        REQUIRE(ms.size() == 2);
+        REQUIRE(ms.count(10) == 2);
+
+        // Insert with hint
+        auto it3 = ms.insert(it1, 15);
+        REQUIRE(*it3 == 15);
+        REQUIRE(ms.size() == 3);
+    }
+
+    SECTION("Emplace operations with duplicates") {
+        auto it1 = ms.emplace(42);
+        REQUIRE(*it1 == 42);
+
+        auto it2 = ms.emplace(42); // Duplicate allowed
+        REQUIRE(*it2 == 42);
+        REQUIRE(ms.count(42) == 2);
+    }
+
+    SECTION("Count operations with duplicates") {
+        REQUIRE(ms_init.count(5) == 2);
+        REQUIRE(ms_init.count(2) == 2);
+        REQUIRE(ms_init.count(8) == 1);
+        REQUIRE(ms_init.count(100) == 0);
+    }
+
+    SECTION("Find operations with duplicates") {
+        auto it = ms_init.find(5);
+        REQUIRE(it != ms_init.end());
+        REQUIRE(*it == 5);
+
+        // Should find any occurrence of the key
+        auto count = 0;
+        for (auto iter = ms_init.begin(); iter != ms_init.end(); ++iter) {
+            if (*iter == 5) count++;
+        }
+        REQUIRE(count == 2);
+    }
+
+    SECTION("Equal range with duplicates") {
+        auto [first, last] = ms_init.equal_range(5);
+        REQUIRE(std::distance(first, last) == 2);
+
+        for (auto it = first; it != last; ++it) {
+            REQUIRE(*it == 5);
+        }
+    }
+
+    SECTION("Erase operations with duplicates") {
+        j::multiset<int> ms_erase = {1, 2, 2, 3, 3, 3, 4};
+
+        // Erase all occurrences by key
+        auto erased_count = ms_erase.erase(3);
+        REQUIRE(erased_count == 3);
+        REQUIRE(!ms_erase.contains(3));
+
+        // Erase single occurrence by iterator
+        auto it = ms_erase.find(2);
+        REQUIRE(it != ms_erase.end());
+        ms_erase.erase(it);
+        REQUIRE(ms_erase.count(2) == 1); // One still remains
+    }
+
+    SECTION("Iterators with duplicates") {
+        std::vector<int> result;
+        for (const auto& val : ms_init) {
+            result.push_back(val);
+        }
+        REQUIRE(ms_init.size() == 8);
+        REQUIRE(std::is_sorted(result.begin(), result.end()));
+        REQUIRE(result.size() == 8);
+    }
+}
+
+TEST_CASE("Set Edge Cases") {
+    SECTION("Empty set operations") {
+        j::set<int> empty_set;
+
+        REQUIRE(empty_set.empty());
+        REQUIRE(empty_set.size() == 0);
+        REQUIRE(empty_set.begin() == empty_set.end());
+        REQUIRE(empty_set.find(1) == empty_set.end());
+        REQUIRE(empty_set.count(1) == 0);
+        REQUIRE(!empty_set.contains(1));
+
+        // Operations on empty set should be safe
+        empty_set.clear(); // Should not crash
+        REQUIRE(empty_set.erase(1) == 0);
+    }
+
+    SECTION("Single element set") {
+        j::set<int> single = {42};
+
+        REQUIRE(single.size() == 1);
+        REQUIRE(!single.empty());
+        REQUIRE(single.contains(42));
+        REQUIRE(*single.begin() == 42);
+        REQUIRE(*single.rbegin() == 42);
+
+        single.erase(42);
+        REQUIRE(single.empty());
+    }
+
+    SECTION("Custom comparator") {
+        j::set<int, std::greater<int>> desc_set = {3, 1, 4, 1, 5};
+
+        std::vector<int> result;
+        for (const auto& val : desc_set) {
+            result.push_back(val);
+        }
+
+        // Should be in descending order
+        REQUIRE(std::is_sorted(result.begin(), result.end(), std::greater<int>()));
+        REQUIRE(result.front() == 5);
+        REQUIRE(result.back() == 1);
+    }
+
+    SECTION("Node extraction and insertion") {
+        j::set<int> s1 = {1, 2, 3};
+        j::set<int> s2 = {4, 5, 6};
+
+        // Extract node
+        auto node = s1.extract(2);
+        REQUIRE(!node.empty());
+        REQUIRE(node.value() == 2);
+        REQUIRE(!s1.contains(2));
+        REQUIRE(s1.size() == 2);
+
+        // Insert node
+        auto result = s2.insert(std::move(node));
+        REQUIRE(result.inserted);
+        REQUIRE(*result.position == 2);
+        REQUIRE(s2.contains(2));
+        REQUIRE(s2.size() == 4);
+    }
+
+    SECTION("Merge operations") {
+        j::set<int> s1 = {1, 3, 5};
+        j::set<int> s2 = {2, 4, 6};
+        j::set<int> s3 = {1, 2, 7}; // Has overlapping elements
+
+        s1.merge(s2);
+        REQUIRE(s1.size() == 6);
+        REQUIRE(s2.empty());
+
+        auto original_size = s1.size();
+        s1.merge(s3);
+        REQUIRE(s1.size() == original_size + 1); // Only 7 is new
+        REQUIRE(s3.size() == 2); // 1 and 2 remain in s3
+    }
+
+    SECTION("Large range operations") {
+        std::vector<int> large_range(1000);
+        std::iota(large_range.begin(), large_range.end(), 1);
+
+        j::set<int> large_set(large_range.begin(), large_range.end());
+        REQUIRE(large_set.size() == 1000);
+
+        // Erase half
+        auto mid = std::next(large_set.begin(), 500);
+        large_set.erase(large_set.begin(), mid);
+        REQUIRE(large_set.size() == 500);
+        REQUIRE(*large_set.begin() >= 501);
+    }
+}
+
+TEST_CASE("MultiSet Edge Cases") {
+    SECTION("Empty multiset operations") {
+        j::multiset<int> empty_ms;
+
+        REQUIRE(empty_ms.empty());
+        REQUIRE(empty_ms.size() == 0);
+        REQUIRE(empty_ms.begin() == empty_ms.end());
+        REQUIRE(empty_ms.find(1) == empty_ms.end());
+        REQUIRE(empty_ms.count(1) == 0);
+        REQUIRE(!empty_ms.contains(1));
+    }
+
+    SECTION("All same elements") {
+        j::multiset<int> all_same = {5, 5, 5, 5, 5};
+
+        REQUIRE(all_same.size() == 5);
+        REQUIRE(all_same.count(5) == 5);
+        REQUIRE(all_same.count(1) == 0);
+
+        auto [first, last] = all_same.equal_range(5);
+        REQUIRE(std::distance(first, last) == 5);
+
+        // Erase one occurrence
+        all_same.erase(all_same.begin());
+        REQUIRE(all_same.count(5) == 4);
+
+        // Erase all occurrences
+        all_same.erase(5);
+        REQUIRE(all_same.empty());
+    }
+
+    SECTION("Custom comparator with duplicates") {
+        j::multiset<int, std::greater<int>> desc_ms = {3, 1, 4, 1, 5, 3};
+
+        std::vector<int> result;
+        for (const auto& val : desc_ms) {
+            result.push_back(val);
+        }
+
+        // Should be in descending order with duplicates
+        REQUIRE(std::is_sorted(result.begin(), result.end(), std::greater<int>()));
+        REQUIRE(desc_ms.count(1) == 2);
+        REQUIRE(desc_ms.count(3) == 2);
+    }
+
+    SECTION("Node operations with duplicates") {
+        j::multiset<int> ms1 = {1, 2, 2, 3};
+        j::multiset<int> ms2 = {4, 5};
+
+        // Extract one occurrence
+        auto node = ms1.extract(ms1.find(2));
+        REQUIRE(!node.empty());
+        REQUIRE(node.value() == 2);
+        REQUIRE(ms1.count(2) == 1); // One still remains
+        REQUIRE(ms1.size() == 3);
+
+        // Insert node
+        auto result = ms2.insert(std::move(node));
+        REQUIRE(*result == 2);
+        REQUIRE(ms2.count(2) == 1);
+        REQUIRE(ms2.size() == 3);
+    }
+
+    SECTION("Merge with duplicates") {
+        j::multiset<int> ms1 = {1, 2, 3, 3};
+        j::multiset<int> ms2 = {2, 3, 4, 4};
+
+        auto original_size1 = ms1.size();
+        auto original_size2 = ms2.size();
+
+        ms1.merge(ms2);
+        REQUIRE(ms1.size() == original_size1 + original_size2);
+        REQUIRE(ms2.empty());
+        REQUIRE(ms1.count(2) == 2);
+        REQUIRE(ms1.count(3) == 3);
+        REQUIRE(ms1.count(4) == 2);
+    }
+}
+
+TEST_CASE("Set Big") {
+    SECTION("Large scale insertion and lookup") {
+        j::set<int> big_set;
+
+        // Insert many elements
+        for (int i = 0; i < N; ++i) {
+            big_set.insert(i * 2); // Even numbers
+        }
+
+        REQUIRE(big_set.size() == N);
+
+        // Verify all elements exist
+        for (int i = 0; i < N; ++i) {
+            REQUIRE(big_set.contains(i * 2));
+            REQUIRE(!big_set.contains(i * 2 + 1)); // Odd numbers don't exist
+        }
+
+        // Performance test - should be fast
+        auto start_time = std::chrono::high_resolution_clock::now();
+        for (int i = 0; i < 1000; ++i) {
+            auto temp = big_set.find(i * 20);
+        }
+        auto end_time = std::chrono::high_resolution_clock::now();
+        auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end_time - start_time);
+
+        // Should complete quickly (adjust threshold as needed)
+        REQUIRE(duration.count() < 10000); // 10ms
+    }
+
+    SECTION("Large scale range operations") {
+        j::set<int> big_set;
+
+        // Insert elements
+        for (int i = 0; i < N; ++i) {
+            big_set.insert(i);
+        }
+
+        // Erase middle half
+        auto first = big_set.lower_bound(N / 4);
+        auto last = big_set.upper_bound(3 * N / 4);
+        big_set.erase(first, last);
+
+        REQUIRE(big_set.size() == N / 2 - 1);
+        REQUIRE(!big_set.contains(N / 2));
+        REQUIRE(big_set.contains(N / 8));
+        REQUIRE(big_set.contains(7 * N / 8));
+    }
+
+    SECTION("Memory efficiency test") {
+        std::vector<j::set<int>> many_sets(100);
+
+        for (auto& s : many_sets) {
+            for (int i = 0; i < 100; ++i) {
+                s.insert(i);
+            }
+        }
+
+        // Verify all sets are properly constructed
+        for (const auto& s : many_sets) {
+            REQUIRE(s.size() == 100);
+            REQUIRE(s.contains(50));
+        }
+    }
+}
+
+TEST_CASE("MultiSet Big") {
+    SECTION("Large scale with many duplicates") {
+        j::multiset<int> big_ms;
+
+        // Insert many duplicates
+        for (int i = 0; i < N; ++i) {
+            for (int j = 0; j < DUPLICATES; ++j) {
+                big_ms.insert(i);
+            }
+        }
+
+        REQUIRE(big_ms.size() == N * DUPLICATES);
+
+        // Verify counts
+        for (int i = 0; i < N; ++i) {
+            REQUIRE(big_ms.count(i) == DUPLICATES);
+        }
+
+        // Test equal_range on large multiset
+        auto [first, last] = big_ms.equal_range(N / 2);
+        REQUIRE(std::distance(first, last) == DUPLICATES);
+    }
+
+    SECTION("Bulk operations performance") {
+        j::multiset<int> ms1, ms2;
+
+        // Populate both multisets
+        for (int i = 0; i < N; ++i) {
+            ms1.insert(i);
+            ms1.insert(i); // Duplicate
+            ms2.insert(i + N / 2);
+            ms2.insert(i + N / 2); // Duplicate
+        }
+
+        // Merge operation on large multisets
+        auto start_time = std::chrono::high_resolution_clock::now();
+        ms1.merge(ms2);
+        auto end_time = std::chrono::high_resolution_clock::now();
+
+        REQUIRE(ms2.empty());
+        REQUIRE(ms1.size() == 4 * N); // Accounting for overlaps
+
+        auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
+        REQUIRE(duration.count() < 100); // Should complete in reasonable time
+    }
+
+    SECTION("Iterator stability test") {
+        j::multiset<int> ms = {1, 2, 2, 3, 3, 3, 4, 4, 4, 4};
+
+        std::vector<j::multiset<int>::iterator> iterators;
+
+        // Collect iterators to all elements
+        for (auto it = ms.begin(); it != ms.end(); ++it) {
+            iterators.push_back(it);
+        }
+
+        // Insert more elements
+        ms.insert(0);
+        ms.insert(5);
+
+        // Original iterators should still be valid (implementation dependent)
+        for (auto it : iterators) {
+            REQUIRE(it != ms.end());
+            REQUIRE((*it >= 1 && *it <= 4));
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces several new modules and updates the build configuration to support new tree-based data structures, specifically sets and maps, along with their associated concepts and traits. It also adds corresponding tests and benchmarks. The main themes are the addition of foundational modules for concepts and traits, new tree-based data structures, and enhancements to the build and test system.

Set and Map will be able to select their underlying tree structure in the future, depending on the chosen base tree. (using tree_selector module)

**New modules and data structures:**

* Added new modules: `concepts.cppm` (concepts for base_tree), `traits.cppm` (traits for set and multiset), and tree-related modules: `tree_selector.cppm`, `map.cppm`, and `set.cppm`. These provide the foundation for implementing and selecting different tree-based containers. [[1]](diffhunk://#diff-c9336ece56c2095f92a2ba26c744b68b503c6c1f101671976698c373c4d17577R1-R40) [[2]](diffhunk://#diff-19ad4261b4fa25c1b249273f5f720fbf96a4866fd893dd0f6f3940a3b2c50432R1-R36) [[3]](diffhunk://#diff-1bd10e9c1d24f7fcebc7ba3338d0e6904a818561a198aa10556894f8fa4af053R1-R42) [[4]](diffhunk://#diff-567a675498b3794357d39d5443ec28cf82f3a79e38d7bbef923f6636ad5e7e7cR1-R7) [[5]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR31-R32) [[6]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR42-R45)

**Build and test system enhancements:**

* Updated `CMakeLists.txt` to include the new modules in the build, and added new test and benchmark executables for the set data structure (`test_set`, `bench_set`). [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR31-R32) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR42-R45) [[3]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR114-R123)
* Registered new tests for `test_stack`, `test_queue`, and `test_set` in the CMake test suite.

**Module exports and imports:**

* Updated `j.cppm` to export/import the new modules (`traits`, `tree_selector`, `map`, `set`) so they are available as part of the main module interface. [[1]](diffhunk://#diff-7f3f79e90c6575001deba9cf0b9f63ef6a4a4710d152f5bd8b5f816dda0f2689R9-R10) [[2]](diffhunk://#diff-7f3f79e90c6575001deba9cf0b9f63ef6a4a4710d152f5bd8b5f816dda0f2689R19-R22)